### PR TITLE
gitmodules: Officially place repos on Github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ceph-object-corpus"]
 	path = ceph-object-corpus
-	url = git://ceph.com/git/ceph-object-corpus.git
+	url = git://github.com/ceph/ceph-object-corpus.git
 [submodule "src/leveldb"]
 	path = src/leveldb
 	url = git://github.com/ceph/leveldb.git


### PR DESCRIPTION
The git repos have moved, and now live on both git.ceph.com and
github.com/ceph.

git://ceph.com/ still works for the moment, but is really a proxy and
deprecated.

Signed-off-by: Robin H. Johnson robbat2@gentoo.org
