### PR TITLE
RGW: avoid returning CURL_READFUNC_PAUSE forever

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -187,7 +187,7 @@ size_t RGWHTTPClient::send_http_data(void * const ptr,
     return 0;
   }
 
-  bool pause;
+  bool pause = false;
 
   int ret = req_data->client->send_data(ptr, size * nmemb, &pause);
   if (ret < 0) {

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -264,6 +264,8 @@ static curl_slist *headers_to_slist(param_vec_t& headers)
     val.append(p.second);
     h = curl_slist_append(h, val.c_str());
   }
+  // disable Expect: 100-contnue header
+  h = curl_slist_append(h, "Expect:");
 
   return h;
 }


### PR DESCRIPTION
this patch could fix that RGWCoroutine blocks in POST request. @yehudasa thank you , would you mind taking a look?

maybe we should use a option `rgw_print_continue` to decide whether we disable "Expect: 100-continue".