### PR TITLE
rgw: avoid returning CURL_READFUNC_PAUSE forever

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -187,7 +187,7 @@ size_t RGWHTTPClient::send_http_data(void * const ptr,
     return 0;
   }
 
-  bool pause;
+  bool pause = false;
 
   int ret = req_data->client->send_data(ptr, size * nmemb, &pause);
   if (ret < 0) {


### PR DESCRIPTION
Signed-off-by: Chang Liu <liuchang0812@gmail.com>