### PR TITLE
rgw/cleanup: fix compile warnning

### DIFF
--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -339,6 +339,7 @@ public:
   virtual int decode_rest_obj(map<string, string>& headers, bufferlist& extra_data, rgw_rest_obj *info) = 0;
   virtual bool has_attrs() = 0;
   virtual void get_attrs(std::map<string, string> *attrs) = 0;
+  virtual ~RGWStreamReadResourceCRF() = default;
 };
 
 class RGWStreamWriteResourceCRF {
@@ -352,6 +353,8 @@ public:
   virtual int send() = 0;
   virtual int write(bufferlist& data, bool *need_retry) = 0; /* reentrant */
   virtual int drain_writes(bool *need_retry) = 0; /* reentrant */
+  
+  virtual ~RGWStreamWriteResourceCRF() = default;
 };
 
 class RGWStreamReadHTTPResourceCRF : public RGWStreamReadResourceCRF {
@@ -391,7 +394,7 @@ public:
                                                                 env(_env),
                                                                 caller(_caller),
                                                                 http_manager(_http_manager) {}
-  virtual ~RGWStreamReadHTTPResourceCRF();
+  ~RGWStreamReadHTTPResourceCRF() override;
 
   int init() override;
   int read(bufferlist *data, uint64_t max, bool *need_retry) override; /* reentrant */
@@ -451,7 +454,7 @@ public:
                                                                caller(_caller),
                                                                http_manager(_http_manager),
                                                                write_drain_notify_cb(this) {}
-  virtual ~RGWStreamWriteHTTPResourceCRF() {}
+  virtual ~RGWStreamWriteHTTPResourceCRF() = default;
 
   int init() override {
     return 0;

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -414,7 +414,7 @@ int RGWHTTPHeadersCollector::receive_header(void * const ptr, const size_t len)
   return 0;
 }
 
-int RGWHTTPTransceiver::send_data(void* ptr, size_t len)
+int RGWHTTPTransceiver::send_data(void* ptr, size_t len, bool* pause)
 {
   int length_to_copy = 0;
   if (post_data_index < post_data.length()) {

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -57,6 +57,7 @@ class RGWIOProvider
 
 public:
   RGWIOProvider() {}
+  virtual ~RGWIOProvider() = default; 
 
   void assign_io(RGWIOIDProvider& io_id_provider, int io_type = -1);
   rgw_io_id get_io_id(int io_type) {
@@ -107,10 +108,8 @@ protected:
   virtual int receive_data(void *ptr, size_t len, bool *pause) {
     return 0;
   }
-  virtual int send_data(void *ptr, size_t len, bool *pause) {
-    return send_data(ptr, len);
-  }
-  virtual int send_data(void *ptr, size_t len) {
+
+  virtual int send_data(void *ptr, size_t len, bool *pause=nullptr) {
     return 0;
   }
 
@@ -269,7 +268,7 @@ public:
   }
 
 protected:
-  int send_data(void* ptr, size_t len) override;
+  int send_data(void* ptr, size_t len, bool *pause=nullptr) override;
 
   int receive_data(void *ptr, size_t len, bool *pause) override {
     read_bl->append((char *)ptr, len);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -149,7 +149,7 @@ int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *_method, const 
   return status;
 }
 
-int RGWHTTPSimpleRequest::send_data(void *ptr, size_t len)
+int RGWHTTPSimpleRequest::send_data(void *ptr, size_t len, bool* pause)
 {
   if (!send_iter)
     return 0;

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -50,7 +50,7 @@ public:
 
   int receive_header(void *ptr, size_t len) override;
   int receive_data(void *ptr, size_t len, bool *pause) override;
-  int send_data(void *ptr, size_t len) override;
+  int send_data(void *ptr, size_t len, bool* pause=nullptr) override;
 
   bufferlist& get_response() { return response; }
 

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -68,10 +68,10 @@ public:
 
   RGWRESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints);
   RGWRESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred);
-
   // custom move needed for atomic
   RGWRESTConn(RGWRESTConn&& other);
   RGWRESTConn& operator=(RGWRESTConn&& other);
+  virtual ~RGWRESTConn() = default;
 
   int get_url(string& endpoint);
   string get_url();
@@ -175,6 +175,7 @@ public:
 
   S3RESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred):
     RGWRESTConn(_cct, store, _remote_id, endpoints, _cred) {}
+  ~S3RESTConn() override = default;
 
   void populate_params(param_vec_t& params, const rgw_user *uid, const string& zonegroup) override {
     // do not populate any params in S3 REST Connection.
@@ -249,6 +250,7 @@ public:
 		      param_vec_t& _params,
 		      param_vec_t *extra_headers,
 		      RGWHTTPManager *_mgr);
+  ~RGWRESTReadResource() = default;
 
   rgw_io_id get_io_id(int io_type) {
     return req.get_io_id(io_type);
@@ -371,6 +373,8 @@ public:
 		      param_vec_t& params,
 		      param_vec_t *extra_headers,
 		      RGWHTTPManager *_mgr);
+
+  ~RGWRESTSendResource() = default;
 
   rgw_io_id get_io_id(int io_type) {
     return req.get_io_id(io_type);


### PR DESCRIPTION
1. overloaded virtual function
2. virtual functions but no virtual destructors

Signed-off-by: Chang Liu <liuchang0812@gmail.com>