### PR TITLE
rgw: bug fix 

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1448,23 +1448,22 @@ static bool char_needs_url_encoding(char c)
   return false;
 }
 
-void url_encode(const string& src, string& dst)
+void url_encode(const string& src, string& dst, bool encode_slash)
 {
   const char *p = src.c_str();
   for (unsigned i = 0; i < src.size(); i++, p++) {
-    if (char_needs_url_encoding(*p)) {
+    if ((!encode_slash && *p == 0x2F) || !char_needs_url_encoding(*p)) {
+      dst.append(p, 1);
+    }else {
       rgw_uri_escape_char(*p, dst);
-      continue;
     }
-
-    dst.append(p, 1);
   }
 }
 
-std::string url_encode(const std::string& src)
+std::string url_encode(const std::string& src, bool encode_slash)
 {
   std::string dst;
-  url_encode(src, dst);
+  url_encode(src, dst, encode_slash);
 
   return dst;
 }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -283,6 +283,11 @@ enum RGWObjCategory {
   RGW_OBJ_CATEGORY_MULTIMETA = 3,
 };
 
+enum HostStyle {
+  PathStyle = 0,
+  VirtualStyle = 1,
+};
+
 /** Store error returns for output at a different point in the program */
 struct rgw_err {
   rgw_err();

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2278,9 +2278,9 @@ extern bool verify_object_permission_no_policy(struct req_state *s,
 extern void rgw_uri_escape_char(char c, string& dst);
 extern std::string url_decode(const boost::string_view& src_str,
                               bool in_query = false);
-extern void url_encode(const std::string& src,
-                       string& dst);
-extern std::string url_encode(const std::string& src);
+extern void url_encode(const std::string& src, string& dst,
+                       bool encode_slash = true);
+extern std::string url_encode(const std::string& src, bool encode_slash = true);
 /* destination should be CEPH_CRYPTO_HMACSHA1_DIGESTSIZE bytes long */
 extern void calc_hmac_sha1(const char *key, int key_len,
                           const char *msg, int msg_len, char *dest);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -104,6 +104,20 @@ static void get_new_date_str(string& date_str)
   date_str = rgw_to_asctime(ceph_clock_now());
 }
 
+static void get_gmt_date_str(string& date_str)
+{
+  auto now_time = ceph::real_clock::now();
+  time_t rawtime = ceph::real_clock::to_time_t(now_time);
+
+  char buffer[80];
+
+  struct tm timeInfo;
+  gmtime_r(&rawtime, &timeInfo);
+  strftime(buffer, sizeof(buffer), "%a, %d %b %Y %H:%M:%S %z", &timeInfo);  
+  
+  date_str = buffer;
+}
+
 int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *_method, const char *resource)
 {
   method = _method;
@@ -431,7 +445,7 @@ void RGWRESTStreamS3PutObj::send_init(rgw_obj& obj)
     new_url.append("/");
 
   string date_str;
-  get_new_date_str(date_str);
+  get_gmt_date_str(date_str);
 
   string params_str;
   map<string, string>& args = new_info.args.get_params();
@@ -588,7 +602,7 @@ int RGWRESTStreamRWRequest::send_prepare(RGWAccessKey *key, map<string, string>&
     new_url.append("/");
 
   string date_str;
-  get_new_date_str(date_str);
+  get_gmt_date_str(date_str);
 
   RGWEnv new_env;
   req_info new_info(cct, &new_env);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -700,9 +700,11 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
   }
 
   if (send_data) {
+    set_send_length(send_data->length());
     set_outbl(*send_data);
     send_data_hint = true;
   }
+  
 
   method = new_info.method;
   url = new_url;

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -591,10 +591,20 @@ int RGWRESTStreamRWRequest::send_prepare(RGWAccessKey& key, map<string, string>&
   string resource;
   send_prepare_convert(obj, &resource);
 
-  return send_prepare(&key, extra_headers, resource);
+  return do_send_prepare(&key, extra_headers, resource);
 }
 
 int RGWRESTStreamRWRequest::send_prepare(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
+                                           bufferlist *send_data)
+{
+  string new_resource;
+  //do not encode slash
+  url_encode(resource, new_resource, false);
+
+  return do_send_prepare(key, extra_headers, new_resource, send_data);
+}
+
+int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
                                          bufferlist *send_data)
 {
   string new_url = url;

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -144,9 +144,11 @@ public:
 
 class RGWRESTStreamRWRequest : public RGWHTTPStreamRWRequest {
   bool send_data_hint{false};
+protected:
+  HostStyle host_style;
 public:
   RGWRESTStreamRWRequest(CephContext *_cct, const string& _method, const string& _url, RGWHTTPStreamRWRequest::ReceiveCB *_cb,
-		param_vec_t *_headers, param_vec_t *_params) : RGWHTTPStreamRWRequest(_cct, _method, _url, _cb, _headers, _params) {
+		param_vec_t *_headers, param_vec_t *_params, HostStyle _host_style = PathStyle) : RGWHTTPStreamRWRequest(_cct, _method, _url, _cb, _headers, _params), host_style(_host_style) {
   }
   virtual ~RGWRESTStreamRWRequest() override {}
 
@@ -168,7 +170,7 @@ private:
 class RGWRESTStreamReadRequest : public RGWRESTStreamRWRequest {
 public:
   RGWRESTStreamReadRequest(CephContext *_cct, const string& _url, ReceiveCB *_cb, param_vec_t *_headers,
-		param_vec_t *_params) : RGWRESTStreamRWRequest(_cct, "GET", _url, _cb, _headers, _params) {}
+		param_vec_t *_params, HostStyle _host_style = PathStyle) : RGWRESTStreamRWRequest(_cct, "GET", _url, _cb, _headers, _params, _host_style) {}
 };
 
 class RGWRESTStreamHeadRequest : public RGWRESTStreamRWRequest {
@@ -183,7 +185,7 @@ class RGWRESTStreamS3PutObj : public RGWRESTStreamRWRequest {
   req_info new_info;
 public:
   RGWRESTStreamS3PutObj(CephContext *_cct, const string& _method, const string& _url, param_vec_t *_headers,
-		param_vec_t *_params) : RGWRESTStreamRWRequest(_cct, _method, _url, nullptr, _headers, _params),
+		param_vec_t *_params, HostStyle _host_style) : RGWRESTStreamRWRequest(_cct, _method, _url, nullptr, _headers, _params, _host_style),
                 out_cb(NULL), new_info(cct, &new_env) {}
   ~RGWRESTStreamS3PutObj() override;
 

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -160,6 +160,9 @@ public:
   int complete_request(string& etag, real_time *mtime, uint64_t *psize, map<string, string>& attrs);
 
   void add_params(param_vec_t *params);
+
+private:
+  int do_send_prepare(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource, bufferlist *send_data = nullptr /* optional input data */);
 };
 
 class RGWRESTStreamReadRequest : public RGWRESTStreamRWRequest {

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -437,7 +437,9 @@ void RGWRESTSendResource::init_common(param_vec_t *extra_headers)
 
 int RGWRESTSendResource::send(bufferlist& outbl)
 {
+  req.set_send_length(outbl.length());
   req.set_outbl(outbl);
+
   int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
@@ -451,7 +453,9 @@ int RGWRESTSendResource::send(bufferlist& outbl)
 
 int RGWRESTSendResource::aio_send(bufferlist& outbl)
 {
+  req.set_send_length(outbl.length());
   req.set_outbl(outbl);
+
   int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
@@ -460,4 +464,3 @@ int RGWRESTSendResource::aio_send(bufferlist& outbl)
 
   return 0;
 }
-

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -62,12 +62,14 @@ class RGWRESTConn
   RGWAccessKey key;
   string self_zone_group;
   string remote_id;
+  HostStyle host_style;
   std::atomic<int64_t> counter = { 0 };
 
 public:
 
-  RGWRESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints);
-  RGWRESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred);
+  RGWRESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints, HostStyle _host_style = PathStyle);
+  RGWRESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred, HostStyle _host_style = PathStyle);
+
   // custom move needed for atomic
   RGWRESTConn(RGWRESTConn&& other);
   RGWRESTConn& operator=(RGWRESTConn&& other);
@@ -83,6 +85,10 @@ public:
   }
   RGWAccessKey& get_key() {
     return key;
+  }
+
+  HostStyle get_host_style() {
+    return host_style;
   }
 
   CephContext *get_ctx() {
@@ -170,11 +176,11 @@ class S3RESTConn : public RGWRESTConn {
 
 public:
 
-  S3RESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints) :
-    RGWRESTConn(_cct, store, _remote_id, endpoints) {}
+  S3RESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints, HostStyle _host_style = PathStyle) :
+    RGWRESTConn(_cct, store, _remote_id, endpoints, _host_style) {}
 
-  S3RESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred):
-    RGWRESTConn(_cct, store, _remote_id, endpoints, _cred) {}
+  S3RESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred, HostStyle _host_style = PathStyle):
+    RGWRESTConn(_cct, store, _remote_id, endpoints, _cred, _host_style) {}
   ~S3RESTConn() override = default;
 
   void populate_params(param_vec_t& params, const rgw_user *uid, const string& zonegroup) override {

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -411,6 +411,7 @@ public:
 
   int wait(bufferlist *pbl) {
     int ret = req.wait();
+    *pbl = bl;
     if (ret < 0) {
       return ret;
     }
@@ -418,7 +419,6 @@ public:
     if (req.get_status() < 0) {
       return req.get_status();
     }
-    *pbl = bl;
     return 0;
   }
 


### PR DESCRIPTION
At now, we can sync data from RGW to COS(support S3 protocol ) as expected, related modifications are as below:
- use `camelcase` format in request headers(e.g: use `Date` instead of `DATE`)
- use time format defined by RFC1123 in request headers
- avoid use Chunked transfer encoding
- add virtual hosted-style support
- add a bucket-suffix tier-config

Hope you can take a review, and we'll be glad if these modifications are useful. @yehudasa 