### PR TITLE
rgw: set correct storage class for RGWListMultipart and RGWListBucketMultiparts

### DIFF
--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -56,6 +56,7 @@ void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
   utime_t ut(mtime);
   encode_json("mtime", ut, f);
   encode_json("etag", etag, f);
+  encode_json("content_type", content_type, f);
   encode_json("owner", owner, f);
   encode_json("owner_display_name", owner_display_name, f);
   encode_json("content_type", content_type, f);
@@ -72,6 +73,7 @@ void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("mtime", ut, obj);
   mtime = ut.to_real_time();
   JSONDecoder::decode_json("etag", etag, obj);
+  JSONDecoder::decode_json("content_type", content_type, obj);
   JSONDecoder::decode_json("owner", owner, obj);
   JSONDecoder::decode_json("owner_display_name", owner_display_name, obj);
   JSONDecoder::decode_json("content_type", content_type, obj);

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -56,7 +56,7 @@ void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
   utime_t ut(mtime);
   encode_json("mtime", ut, f);
   encode_json("etag", etag, f);
-  encode_json("content_type", content_type, f);
+  encode_json("storage_class", storage_class, f);
   encode_json("owner", owner, f);
   encode_json("owner_display_name", owner_display_name, f);
   encode_json("content_type", content_type, f);
@@ -73,7 +73,7 @@ void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("mtime", ut, obj);
   mtime = ut.to_real_time();
   JSONDecoder::decode_json("etag", etag, obj);
-  JSONDecoder::decode_json("content_type", content_type, obj);
+  JSONDecoder::decode_json("storage_class", storage_class, obj);
   JSONDecoder::decode_json("owner", owner, obj);
   JSONDecoder::decode_json("owner_display_name", owner_display_name, obj);
   JSONDecoder::decode_json("content_type", content_type, obj);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -101,12 +101,13 @@ struct rgw_bucket_dir_entry_meta {
   string content_type;
   uint64_t accounted_size;
   string user_data;
+  string storage_class;
 
   rgw_bucket_dir_entry_meta() :
   category(0), size(0), accounted_size(0) { }
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(5, 3, bl);
+    ENCODE_START(6, 3, bl);
     encode(category, bl);
     encode(size, bl);
     encode(mtime, bl);
@@ -116,10 +117,11 @@ struct rgw_bucket_dir_entry_meta {
     encode(content_type, bl);
     encode(accounted_size, bl);
     encode(user_data, bl);
+    encode(storage_class, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(5, 3, 3, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(6, 3, 3, bl);
     decode(category, bl);
     decode(size, bl);
     decode(mtime, bl);
@@ -134,6 +136,8 @@ struct rgw_bucket_dir_entry_meta {
       accounted_size = size;
     if (struct_v >= 5)
       decode(user_data, bl);
+    if (struct_v >= 6)
+      decode(storage_class, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -30,6 +30,9 @@ namespace ceph {
       ObjectSection(Formatter& f, const char *name) : formatter(f) {
         formatter.open_object_section(name);
       }
+      ObjectSection(Formatter& f, const char *name, const char *ns) : formatter(f) {
+        formatter.open_object_section_in_ns(name, ns);
+      }
       ~ObjectSection() {
         formatter.close_section();
       }
@@ -40,6 +43,9 @@ namespace ceph {
     public:
       ArraySection(Formatter& f, const char *name) : formatter(f) {
         formatter.open_array_section(name);
+      }
+      ArraySection(Formatter& f, const char *name, const char *ns) : formatter(f) {
+        formatter.open_array_section_in_ns(name, ns);
       }
       ~ArraySection() {
         formatter.close_section();

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -558,12 +558,6 @@ struct JSONFormattable {
     return def(string(def_val));
   }
 
-#if 0
-  string operator ()(const string& def_val) const {
-    return def(def_val);
-  }
-#endif
-
   int operator()(int def_val) const {
     return def(def_val);
   }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4688,19 +4688,14 @@ int main(int argc, const char **argv)
           RGWZonePlacementInfo& info = zone.placement_pools[placement_id];
 
           info.index_pool = *index_pool;
-          if (storage_class.empty()) {
-            info.data_pools[RGW_STORAGE_CLASS_STANDARD] = *data_pool;
-          } else {
-            info.data_pools[storage_class] = *data_pool;
-          }
+          rgw_pool dp = data_pool.get();
+          info.storage_classes.set_storage_class(storage_class, &dp, compression_type.get_ptr());
+
           if (data_extra_pool) {
             info.data_extra_pool = *data_extra_pool;
           }
           if (index_type_specified) {
             info.index_type = placement_index_type;
-          }
-          if (compression_type) {
-            info.compression_type = *compression_type;
           }
 
           ret = check_pool_support_omap(info.get_data_extra_pool());
@@ -4720,21 +4715,14 @@ int main(int argc, const char **argv)
           if (index_pool && !index_pool->empty()) {
             info.index_pool = *index_pool;
           }
-          if (data_pool && !data_pool->empty()) {
-            if (storage_class.empty()) {
-              info.data_pools[RGW_STORAGE_CLASS_STANDARD] = *data_pool;
-            } else {
-              info.data_pools[storage_class] = *data_pool;
-            }
-          }
+          rgw_pool dp = data_pool.get();
+          info.storage_classes.set_storage_class(storage_class, &dp, compression_type.get_ptr());
+
           if (data_extra_pool) {
             info.data_extra_pool = *data_extra_pool;
           }
           if (index_type_specified) {
             info.index_type = placement_index_type;
-          }
-          if (compression_type) {
-            info.compression_type = *compression_type;
           }
           
           ret = check_pool_support_omap(info.get_data_extra_pool());

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1233,11 +1233,8 @@ static bool decode_dump(const char *field_name, bufferlist& bl, Formatter *f)
 
 static bool dump_string(const char *field_name, bufferlist& bl, Formatter *f)
 {
-  string val;
-  if (bl.length() > 0) {
-    val.assign(bl.c_str());
-  }
-  f->dump_string(field_name, val);
+  string val = bl.to_str();
+  f->dump_string(field_name, val.c_str() /* hide encoded null termination chars */);
 
   return true;
 }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -283,6 +283,7 @@ void usage()
   cout << "   --read-only               set zone as read-only (when adding to zonegroup)\n";
   cout << "   --redirect-zone           specify zone id to redirect when response is 404 (not found)\n";
   cout << "   --placement-id            placement id for zonegroup placement commands\n";
+  cout << "   --storage-class           storage class for zonegroup placement commands\n";
   cout << "   --tags=<list>             list of tags for zonegroup placement add and modify commands\n";
   cout << "   --tags-add=<list>         list of tags to add for zonegroup placement modify command\n";
   cout << "   --tags-rm=<list>          list of tags to remove for zonegroup placement modify command\n";
@@ -2730,6 +2731,7 @@ int main(int argc, const char **argv)
   string quota_scope;
   string object_version;
   string placement_id;
+  string storage_class;
   list<string> tags;
   list<string> tags_add;
   list<string> tags_rm;
@@ -3034,6 +3036,8 @@ int main(int argc, const char **argv)
       zonegroup_new_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-id", (char*)NULL)) {
       placement_id = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--storage-class", (char*)NULL)) {
+      storage_class = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--tags", (char*)NULL)) {
       get_str_list(val, tags);
     } else if (ceph_argparse_witharg(args, i, &val, "--tags-add", (char*)NULL)) {
@@ -4197,6 +4201,17 @@ int main(int argc, const char **argv)
           return EINVAL;
         }
 
+        rgw_placement_rule rule;
+        rule.from_str(placement_id);
+
+        if (!rule.storage_class.empty() && !storage_class.empty() &&
+            rule.storage_class != storage_class) {
+          cerr << "ERROR: provided contradicting storage class configuration" << std::endl;
+          return EINVAL;
+        } else if (rule.storage_class.empty()) {
+          rule.storage_class = storage_class;
+        }
+
 	RGWZoneGroup zonegroup(zonegroup_id, zonegroup_name);
 	int ret = zonegroup.init(g_ceph_context, store->svc.sysobj);
 	if (ret < 0) {
@@ -4204,14 +4219,8 @@ int main(int argc, const char **argv)
 	  return -ret;
 	}
 
-        if (opt_cmd == OPT_ZONEGROUP_PLACEMENT_ADD) {
-          RGWZoneGroupPlacementTarget target;
-          target.name = placement_id;
-          for (auto& t : tags) {
-            target.tags.insert(t);
-          }
-          zonegroup.placement_targets[placement_id] = target;
-        } else if (opt_cmd == OPT_ZONEGROUP_PLACEMENT_MODIFY) {
+        if (opt_cmd == OPT_ZONEGROUP_PLACEMENT_ADD ||
+            opt_cmd == OPT_ZONEGROUP_PLACEMENT_MODIFY) {
           RGWZoneGroupPlacementTarget& target = zonegroup.placement_targets[placement_id];
           if (!tags.empty()) {
             target.tags.clear();
@@ -4226,6 +4235,7 @@ int main(int argc, const char **argv)
           for (auto& t : tags_add) {
             target.tags.insert(t);
           }
+          target.storage_classes.insert(rule.get_storage_class());
         } else if (opt_cmd == OPT_ZONEGROUP_PLACEMENT_RM) {
           zonegroup.placement_targets.erase(placement_id);
         } else if (opt_cmd == OPT_ZONEGROUP_PLACEMENT_DEFAULT) {
@@ -4234,7 +4244,7 @@ int main(int argc, const char **argv)
                 << placement_id << "'" << std::endl;
             return -ENOENT;
           }
-          zonegroup.default_placement = placement_id;
+          zonegroup.default_placement = rule;
         }
 
         zonegroup.post_process_params();
@@ -4678,7 +4688,11 @@ int main(int argc, const char **argv)
           RGWZonePlacementInfo& info = zone.placement_pools[placement_id];
 
           info.index_pool = *index_pool;
-          info.data_pool = *data_pool;
+          if (storage_class.empty()) {
+            info.data_pools[RGW_STORAGE_CLASS_STANDARD] = *data_pool;
+          } else {
+            info.data_pools[storage_class] = *data_pool;
+          }
           if (data_extra_pool) {
             info.data_extra_pool = *data_extra_pool;
           }
@@ -4707,7 +4721,11 @@ int main(int argc, const char **argv)
             info.index_pool = *index_pool;
           }
           if (data_pool && !data_pool->empty()) {
-            info.data_pool = *data_pool;
+            if (storage_class.empty()) {
+              info.data_pools[RGW_STORAGE_CLASS_STANDARD] = *data_pool;
+            } else {
+              info.data_pools[storage_class] = *data_pool;
+            }
           }
           if (data_extra_pool) {
             info.data_extra_pool = *data_extra_pool;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1434,7 +1434,7 @@ static int bucket_stats(RGWRados *store, const std::string& tenant_name, std::st
   formatter->dump_string("bucket", bucket.name);
   formatter->dump_string("tenant", bucket.tenant);
   formatter->dump_string("zonegroup", bucket_info.zonegroup);
-  formatter->dump_string("placement_rule", bucket_info.placement_rule);
+  formatter->dump_string("placement_rule", bucket_info.placement_rule.to_str());
   ::encode_json("explicit_placement", bucket.explicit_placement, formatter);
   formatter->dump_string("id", bucket.bucket_id);
   formatter->dump_string("marker", bucket.marker);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -752,6 +752,25 @@ void decode_json_obj(rgw_placement_rule& v, JSONObj *obj);
 inline ostream& operator<<(ostream& out, const rgw_placement_rule& rule) {
   return out << rule.to_str();
 }
+
+struct multipart_upload_info
+{
+  rgw_placement_rule dest_placement;
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(dest_placement, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(dest_placement, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(multipart_upload_info)
+
 struct RGWUserInfo
 {
   rgw_user user_id;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -646,7 +646,13 @@ struct rgw_placement_rule {
 
   rgw_placement_rule() {}
   rgw_placement_rule(const string& _n, const string& _sc) : name(_n), storage_class(_sc) {}
-
+  rgw_placement_rule(const rgw_placement_rule& _r, const string& _sc) : name(_r.name) {
+    if (!_sc.empty()) {
+      storage_class = _sc;
+    } else {
+      storage_class = _r.storage_class;
+    }
+  }
 
   bool empty() const {
     return name.empty() && storage_class.empty();
@@ -1600,7 +1606,7 @@ struct req_info {
   string effective_uri;
   string request_params;
   string domain;
-  rgw_placement_rule storage_class;
+  string storage_class;
 
   req_info(CephContext *cct, const RGWEnv *env);
   void rebuild_from(req_info& src);
@@ -1952,6 +1958,7 @@ struct req_state : DoutPrefixProvider {
   real_time bucket_mtime;
   std::map<std::string, ceph::bufferlist> bucket_attrs;
   bool bucket_exists{false};
+  rgw_placement_rule dest_placement;
 
   bool has_bad_meta{false};
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -707,7 +707,7 @@ struct rgw_placement_rule {
 
   void encode(bufferlist& bl) const {
     /* no ENCODE_START/END due to backward compatibility */
-    std::string s = to_str();
+    std::string s = to_str_explicit();
     ceph::encode(s, bl);
   }
 
@@ -721,6 +721,10 @@ struct rgw_placement_rule {
     if (standard_storage_class()) {
       return name;
     }
+    return to_str_explicit();
+  }
+
+  std::string to_str_explicit() const {
     return name + "/" + storage_class;
   }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -671,11 +671,15 @@ struct rgw_placement_rule {
     storage_class = c;
   }
 
-  const string& get_storage_class() const {
+  static const string& get_canonical_storage_class(const string& storage_class) {
     if (storage_class.empty()) {
       return RGW_STORAGE_CLASS_STANDARD;
     }
     return storage_class;
+  }
+
+  const string& get_storage_class() const {
+    return get_canonical_storage_class(storage_class);
   }
   
   int compare(const rgw_placement_rule& r) const {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -652,6 +652,15 @@ struct rgw_placement_rule {
     return name.empty() && storage_class.empty();
   }
 
+  void inherit_from(const rgw_placement_rule& r) {
+    if (name.empty()) {
+      name = r.name;
+    }
+    if (storage_class.empty()) {
+      storage_class = r.storage_class;
+    }
+  }
+
   void clear() {
     name.clear();
     storage_class.clear();
@@ -1587,7 +1596,7 @@ struct req_info {
   string effective_uri;
   string request_params;
   string domain;
-  string storage_class;
+  rgw_placement_rule storage_class;
 
   req_info(CephContext *cct, const RGWEnv *env);
   void rebuild_from(req_info& src);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -76,6 +76,7 @@ using ceph::crypto::MD5;
  * user through custom HTTP header named X-Static-Large-Object. */
 #define RGW_ATTR_SLO_UINDICATOR RGW_ATTR_META_PREFIX "static-large-object"
 #define RGW_ATTR_X_ROBOTS_TAG	RGW_ATTR_PREFIX "x-robots-tag"
+#define RGW_ATTR_STORAGE_CLASS  RGW_ATTR_PREFIX "storage_class"
 
 #define RGW_ATTR_PG_VER 	RGW_ATTR_PREFIX "pg_ver"
 #define RGW_ATTR_SOURCE_ZONE    RGW_ATTR_PREFIX "source_zone"
@@ -637,6 +638,97 @@ enum RGWUserSourceType
   TYPE_LDAP=3
 };
 
+static string RGW_STORAGE_CLASS_STANDARD = "STANDARD";
+
+struct rgw_placement_rule {
+  std::string name;
+  std::string storage_class;
+
+  rgw_placement_rule() {}
+  rgw_placement_rule(const string& _n, const string& _sc) : name(_n), storage_class(_sc) {}
+
+
+  bool empty() const {
+    return name.empty() && storage_class.empty();
+  }
+
+  void clear() {
+    name.clear();
+    storage_class.clear();
+  }
+
+  void init(const string& n, const string& c) {
+    name = n;
+    storage_class = c;
+  }
+
+  const string& get_storage_class() const {
+    if (storage_class.empty()) {
+      return RGW_STORAGE_CLASS_STANDARD;
+    }
+    return storage_class;
+  }
+  
+  int compare(const rgw_placement_rule& r) const {
+    int c = name.compare(r.name);
+    if (c != 0) {
+      return c;
+    }
+    return get_storage_class().compare(r.get_storage_class());
+  }
+
+  bool operator==(const rgw_placement_rule& r) const {
+    return (name == r.name &&
+            get_storage_class() == r.get_storage_class());
+  }
+
+  bool operator!=(const rgw_placement_rule& r) const {
+    return !(*this == r);
+  }
+
+  void encode(bufferlist& bl) const {
+    /* no ENCODE_START/END due to backward compatibility */
+    std::string s = to_str();
+    ceph::encode(s, bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    std::string s;
+    ceph::decode(s, bl);
+    from_str(s);
+  } 
+
+  std::string to_str() const {
+    if (standard_storage_class()) {
+      return name;
+    }
+    return name + "/" + storage_class;
+  }
+
+  void from_str(const std::string& s) {
+    size_t pos = s.find("/");
+    if (pos == std::string::npos) {
+      name = s;
+      return;
+    }
+    name = s.substr(0, pos);
+    if (pos < s.size() - 1) {
+      storage_class = s.substr(pos + 1);
+    }
+  }
+
+  bool standard_storage_class() const {
+    return storage_class.empty() || storage_class == RGW_STORAGE_CLASS_STANDARD;
+  }
+};
+WRITE_CLASS_ENCODER(rgw_placement_rule)
+
+void encode_json(const char *name, const rgw_placement_rule& val, ceph::Formatter *f);
+void decode_json_obj(rgw_placement_rule& v, JSONObj *obj);
+
+inline ostream& operator<<(ostream& out, const rgw_placement_rule& rule) {
+  return out << rule.to_str();
+}
 struct RGWUserInfo
 {
   rgw_user user_id;
@@ -651,7 +743,7 @@ struct RGWUserInfo
   RGWUserCaps caps;
   __u8 admin;
   __u8 system;
-  string default_placement;
+  rgw_placement_rule default_placement;
   list<string> placement_tags;
   RGWQuotaInfo bucket_quota;
   map<int, string> temp_url_keys;
@@ -1242,7 +1334,7 @@ struct RGWBucketInfo {
   uint32_t flags;
   string zonegroup;
   ceph::real_time creation_time;
-  string placement_rule;
+  rgw_placement_rule placement_rule;
   bool has_instance_obj;
   RGWObjVersionTracker objv_tracker; /* we don't need to serialize this, for runtime tracking */
   obj_version ep_objv; /* entry point object version, for runtime tracking only */
@@ -1495,6 +1587,7 @@ struct req_info {
   string effective_uri;
   string request_params;
   string domain;
+  string storage_class;
 
   req_info(CephContext *cct, const RGWEnv *env);
   void rebuild_from(req_info& src);
@@ -1952,7 +2045,7 @@ struct RGWBucketEnt {
   /* The placement_rule is necessary to calculate per-storage-policy statics
    * of the Swift API. Although the info available in RGWBucketInfo, we need
    * to duplicate it here to not affect the performance of buckets listing. */
-  std::string placement_rule;
+  rgw_placement_rule placement_rule;
 
   RGWBucketEnt()
     : size(0),
@@ -1996,7 +2089,7 @@ struct RGWBucketEnt {
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(6, 5, 5, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(7, 5, 5, bl);
     __u32 mt;
     uint64_t s;
     string empty_str;  // backward compatibility

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1328,6 +1328,7 @@ namespace rgw {
       }
     }
     processor.emplace(&*aio, get_store(), s->bucket_info,
+                      &s->dest_placement,
                       s->bucket_owner.get_id(),
                       *static_cast<RGWObjectCtx *>(s->obj_ctx),
                       obj, olh_epoch, s->req_id);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -998,6 +998,7 @@ void RGWZoneStorageClasses::decode_json(JSONObj *obj)
 
     decode_json_obj(m[field.first], field_obj);
   }
+  standard_class = &m[RGW_STORAGE_CLASS_STANDARD];
 }
 
 void RGWZonePlacementInfo::dump(Formatter *f) const

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -31,7 +31,7 @@ const char* LC_STATUS[] = {
 
 using namespace librados;
 
-bool LCRule::valid()
+bool LCRule::valid() const
 {
   if (id.length() > MAX_ID_LEN) {
     return false;
@@ -66,33 +66,32 @@ bool LCRule::valid()
   return true;
 }
 
-void RGWLifecycleConfiguration::add_rule(LCRule *rule)
+void RGWLifecycleConfiguration::add_rule(const LCRule& rule)
 {
-  string id;
-  rule->get_id(id); // note that this will return false for groups, but that's ok, we won't search groups
-  rule_map.insert(pair<string, LCRule>(id, *rule));
+  auto& id = rule.get_id(); // note that this will return false for groups, but that's ok, we won't search groups
+  rule_map.insert(pair<string, LCRule>(id, rule));
 }
 
-bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
+bool RGWLifecycleConfiguration::_add_rule(const LCRule& rule)
 {
   lc_op op;
-  if (rule->get_status().compare("Enabled") == 0) {
+  if (rule.get_status().compare("Enabled") == 0) {
     op.status = true;
   }
-  if (rule->get_expiration().has_days()) {
-    op.expiration = rule->get_expiration().get_days();
+  if (rule.get_expiration().has_days()) {
+    op.expiration = rule.get_expiration().get_days();
   }
-  if (rule->get_expiration().has_date()) {
-    op.expiration_date = ceph::from_iso_8601(rule->get_expiration().get_date());
+  if (rule.get_expiration().has_date()) {
+    op.expiration_date = ceph::from_iso_8601(rule.get_expiration().get_date());
   }
-  if (rule->get_noncur_expiration().has_days()) {
-    op.noncur_expiration = rule->get_noncur_expiration().get_days();
+  if (rule.get_noncur_expiration().has_days()) {
+    op.noncur_expiration = rule.get_noncur_expiration().get_days();
   }
-  if (rule->get_mp_expiration().has_days()) {
-    op.mp_expiration = rule->get_mp_expiration().get_days();
+  if (rule.get_mp_expiration().has_days()) {
+    op.mp_expiration = rule.get_mp_expiration().get_days();
   }
-  op.dm_expiration = rule->get_dm_expiration();
-  for (const auto &elem : rule->get_transitions()) {
+  op.dm_expiration = rule.get_dm_expiration();
+  for (const auto &elem : rule.get_transitions()) {
     transition_action action;
     if (elem.second.has_days()) {
       action.days = elem.second.get_days();
@@ -102,7 +101,7 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
     action.storage_class = elem.first;
     op.transitions.emplace(elem.first, std::move(action));
   }
-  for (const auto &elem : rule->get_noncur_transitions()) {
+  for (const auto &elem : rule.get_noncur_transitions()) {
     transition_action action;
     action.days = elem.second.get_days();
     action.date = ceph::from_iso_8601(elem.second.get_date());
@@ -110,30 +109,29 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
     op.noncur_transitions.emplace(elem.first, std::move(action));
   }
   std::string prefix;
-  if (rule->get_filter().has_prefix()){
-    prefix = rule->get_filter().get_prefix();
+  if (rule.get_filter().has_prefix()){
+    prefix = rule.get_filter().get_prefix();
   } else {
-    prefix = rule->get_prefix();
+    prefix = rule.get_prefix();
   }
 
-  if (rule->get_filter().has_tags()){
-    op.obj_tags = rule->get_filter().get_tags();
+  if (rule.get_filter().has_tags()){
+    op.obj_tags = rule.get_filter().get_tags();
   }
   auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
   return ret.second;
 }
 
-int RGWLifecycleConfiguration::check_and_add_rule(LCRule *rule)
+int RGWLifecycleConfiguration::check_and_add_rule(const LCRule& rule)
 {
-  if (!rule->valid()) {
+  if (!rule.valid()) {
     return -EINVAL;
   }
-  string id;
-  rule->get_id(id);
+  auto& id = rule.get_id();
   if (rule_map.find(id) != rule_map.end()) {  //id shouldn't be the same 
     return -EINVAL;
   }
-  rule_map.insert(pair<string, LCRule>(id, *rule));
+  rule_map.insert(pair<string, LCRule>(id, rule));
 
   if (!_add_rule(rule)) {
     return -ERR_INVALID_REQUEST;

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -100,14 +100,14 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
       action.date = ceph::from_iso_8601(elem.second.get_date());
     }
     action.storage_class = elem.first;
-    op.transitions.emplace(action.storage_class, std::move(action));
+    op.transitions.emplace(elem.first, std::move(action));
   }
   for (const auto &elem : rule->get_noncur_transitions()) {
     transition_action action;
     action.days = elem.second.get_days();
     action.date = ceph::from_iso_8601(elem.second.get_date());
     action.storage_class = elem.first;
-    op.noncur_transitions.emplace(action.storage_class, std::move(action));
+    op.noncur_transitions.emplace(elem.first, std::move(action));
   }
   std::string prefix;
   if (rule->get_filter().has_prefix()){

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -36,12 +36,33 @@ bool LCRule::valid()
   if (id.length() > MAX_ID_LEN) {
     return false;
   }
-  else if(expiration.empty() && noncur_expiration.empty() && mp_expiration.empty() && !dm_expiration) {
+  else if(expiration.empty() && noncur_expiration.empty() && mp_expiration.empty() && !dm_expiration &&
+          transitions.empty() && noncur_transitions.empty()) {
     return false;
   }
   else if (!expiration.valid() || !noncur_expiration.valid() || !mp_expiration.valid()) {
     return false;
   }
+  if (!transitions.empty()) {
+    bool using_days = expiration.has_days();
+    bool using_date = expiration.has_date();
+    for (const auto& elem : transitions) {
+      if (!elem.second.valid()) {
+        return false;
+      }
+      using_days = using_days || elem.second.has_days();
+      using_date = using_date || elem.second.has_date();
+      if (using_days && using_date) {
+        return false;
+      }
+    }
+  }
+  for (const auto& elem : noncur_transitions) {
+    if (!elem.second.valid()) {
+      return false;
+    }
+  }
+
   return true;
 }
 
@@ -71,7 +92,23 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
     op.mp_expiration = rule->get_mp_expiration().get_days();
   }
   op.dm_expiration = rule->get_dm_expiration();
-
+  for (const auto &elem : rule->get_transitions()) {
+    transition_action action;
+    if (elem.second.has_days()) {
+      action.days = elem.second.get_days();
+    } else {
+      action.date = ceph::from_iso_8601(elem.second.get_date());
+    }
+    action.storage_class = elem.first;
+    op.transitions.emplace(action.storage_class, std::move(action));
+  }
+  for (const auto &elem : rule->get_noncur_transitions()) {
+    transition_action action;
+    action.days = elem.second.get_days();
+    action.date = ceph::from_iso_8601(elem.second.get_date());
+    action.storage_class = elem.first;
+    op.noncur_transitions.emplace(action.storage_class, std::move(action));
+  }
   std::string prefix;
   if (rule->get_filter().has_prefix()){
     prefix = rule->get_filter().get_prefix();
@@ -112,9 +149,20 @@ bool RGWLifecycleConfiguration::has_same_action(const lc_op& first, const lc_op&
     return true;
   } else if (first.mp_expiration > 0 && second.mp_expiration > 0) {
     return true;
-  } else {
-    return false;
+  } else if (!first.transitions.empty() && !second.transitions.empty()) {
+    for (auto &elem : first.transitions) {
+      if (second.transitions.find(elem.first) != second.transitions.end()) {
+        return true;
+      }
+    }
+  } else if (!first.noncur_transitions.empty() && !second.noncur_transitions.empty()) {
+    for (auto &elem : first.noncur_transitions) {
+      if (second.noncur_transitions.find(elem.first) != second.noncur_transitions.end()) {
+        return true;
+      }
+    }
   }
+  return false;
 }
 
 //Rules are conflicted: if one rule's prefix starts with other rule's prefix, and these two rules

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -33,7 +33,7 @@ typedef enum {
   lc_processing,
   lc_failed,
   lc_complete,
-}LC_BUCKET_STATUS;
+} LC_BUCKET_STATUS;
 
 class LCExpiration
 {
@@ -43,7 +43,7 @@ protected:
   string date;
 public:
   LCExpiration() {}
-  ~LCExpiration() {}
+  LCExpiration(const string& _days, const string& _date) : days(_days), date(_date) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(3, 2, bl);
@@ -89,7 +89,7 @@ public:
     return true;
   }
 };
-WRITE_CLASS_ENCODER(LCExpiration);
+WRITE_CLASS_ENCODER(LCExpiration)
 
 class LCTransition
 {
@@ -150,7 +150,7 @@ public:
   }
   void dump(Formatter *f) const;
 };
-WRITE_CLASS_ENCODER(LCTransition);
+WRITE_CLASS_ENCODER(LCTransition)
 
 class LCFilter
 {
@@ -206,7 +206,7 @@ class LCFilter
   }
   void dump(Formatter *f) const;
 };
-WRITE_CLASS_ENCODER(LCFilter);
+WRITE_CLASS_ENCODER(LCFilter)
 
 
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -35,6 +35,13 @@ typedef enum {
   lc_complete,
 }LC_BUCKET_STATUS;
 
+typedef enum {
+  standard_ia = 0,
+  onezone_ia,
+  glacier,
+  undefined,
+} STORAGE_CLASS;
+
 class LCExpiration
 {
 protected:
@@ -89,7 +96,80 @@ public:
     return true;
   }
 };
-WRITE_CLASS_ENCODER(LCExpiration)
+WRITE_CLASS_ENCODER(LCExpiration);
+
+class LCTransition
+{
+protected:
+  string days;
+  string date;
+  string storage_class;
+
+public:
+  int get_days() const {
+    return atoi(days.c_str());
+  }
+
+  string get_date() const {
+    return date;
+  }
+
+  string get_storage_class_str() const {
+    return storage_class;
+  }
+
+  STORAGE_CLASS get_storage_class() const {
+    if (storage_class.compare("STANDARD_IA") == 0) {
+      return standard_ia;
+    } else if (storage_class.compare("ONEZONE_IA") == 0) {
+      return onezone_ia;
+    } else if (storage_class.compare("GLACIER") == 0) {
+      return glacier;
+    } else {
+      return undefined;
+    }
+  }
+
+  bool has_days() const {
+    return !days.empty();
+  }
+
+  bool has_date() const {
+    return !date.empty();
+  }
+
+  bool empty() const {
+    return days.empty() && date.empty();
+  }
+
+  bool valid() const {
+    if (!days.empty() && !date.empty()) {
+      return false;
+    } else if (!days.empty() && get_days() <=0) {
+      return false;
+    }
+    //We've checked date in xml parsing
+    return true;
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(days, bl);
+    encode(date, bl);
+    encode(storage_class, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(days, bl);
+    decode(date, bl);
+    decode(storage_class, bl);
+    DECODE_FINISH(bl);
+  }
+  void dump(Formatter *f) const;
+};
+WRITE_CLASS_ENCODER(LCTransition);
 
 class LCFilter
 {
@@ -159,6 +239,8 @@ protected:
   LCExpiration noncur_expiration;
   LCExpiration mp_expiration;
   LCFilter filter;
+  map<int, LCTransition> transitions;
+  map<int, LCTransition> noncur_transitions;
   bool dm_expiration = false;
 
 public:
@@ -199,6 +281,14 @@ public:
     return dm_expiration;
   }
 
+  map<int, LCTransition>& get_transitions() {
+    return transitions;
+  }
+
+  map<int, LCTransition>& get_noncur_transitions() {
+    return noncur_transitions;
+  }
+
   void set_id(string*_id) {
     id = *_id;
   }
@@ -227,10 +317,20 @@ public:
     dm_expiration = _dm_expiration;
   }
 
+  bool add_transition(LCTransition* _transition) {
+    auto ret = transitions.emplace(_transition->get_storage_class(), *_transition);
+    return ret.second;
+  }
+
+  bool add_noncur_transition(LCTransition* _noncur_transition) {
+    auto ret = noncur_transitions.emplace(_noncur_transition->get_storage_class(), *_noncur_transition);
+    return ret.second;
+  }
+
   bool valid();
   
   void encode(bufferlist& bl) const {
-     ENCODE_START(5, 1, bl);
+     ENCODE_START(6, 1, bl);
      encode(id, bl);
      encode(prefix, bl);
      encode(status, bl);
@@ -239,10 +339,12 @@ public:
      encode(mp_expiration, bl);
      encode(dm_expiration, bl);
      encode(filter, bl);
+     encode(transitions, bl);
+     encode(noncur_transitions, bl);
      ENCODE_FINISH(bl);
    }
    void decode(bufferlist::const_iterator& bl) {
-     DECODE_START_LEGACY_COMPAT_LEN(5, 1, 1, bl);
+     DECODE_START_LEGACY_COMPAT_LEN(6, 1, 1, bl);
      decode(id, bl);
      decode(prefix, bl);
      decode(status, bl);
@@ -259,12 +361,24 @@ public:
      if (struct_v >= 5) {
        decode(filter, bl);
      }
+     if (struct_v >= 6) {
+       decode(transitions, bl);
+       decode(noncur_transitions, bl);
+     }
      DECODE_FINISH(bl);
    }
   void dump(Formatter *f) const;
 
 };
 WRITE_CLASS_ENCODER(LCRule)
+
+struct transition_action
+{
+  int days;
+  boost::optional<ceph::real_time> date;
+  int storage_class;
+  transition_action() : days(0), storage_class(standard_ia) {}
+};
 
 struct lc_op
 {
@@ -275,6 +389,8 @@ struct lc_op
   int mp_expiration;
   boost::optional<ceph::real_time> expiration_date;
   boost::optional<RGWObjTags> obj_tags;
+  map<int, transition_action> transitions;
+  map<int, transition_action> noncur_transitions;
   lc_op() : status(false), dm_expiration(false), expiration(0), noncur_expiration(0), mp_expiration(0) {}
   
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -35,13 +35,6 @@ typedef enum {
   lc_complete,
 }LC_BUCKET_STATUS;
 
-typedef enum {
-  standard_ia = 0,
-  onezone_ia,
-  glacier,
-  undefined,
-} STORAGE_CLASS;
-
 class LCExpiration
 {
 protected:
@@ -114,20 +107,8 @@ public:
     return date;
   }
 
-  string get_storage_class_str() const {
+  string get_storage_class() const {
     return storage_class;
-  }
-
-  STORAGE_CLASS get_storage_class() const {
-    if (storage_class.compare("STANDARD_IA") == 0) {
-      return standard_ia;
-    } else if (storage_class.compare("ONEZONE_IA") == 0) {
-      return onezone_ia;
-    } else if (storage_class.compare("GLACIER") == 0) {
-      return glacier;
-    } else {
-      return undefined;
-    }
   }
 
   bool has_days() const {
@@ -239,8 +220,8 @@ protected:
   LCExpiration noncur_expiration;
   LCExpiration mp_expiration;
   LCFilter filter;
-  map<int, LCTransition> transitions;
-  map<int, LCTransition> noncur_transitions;
+  map<string, LCTransition> transitions;
+  map<string, LCTransition> noncur_transitions;
   bool dm_expiration = false;
 
 public:
@@ -281,11 +262,11 @@ public:
     return dm_expiration;
   }
 
-  map<int, LCTransition>& get_transitions() {
+  map<string, LCTransition>& get_transitions() {
     return transitions;
   }
 
-  map<int, LCTransition>& get_noncur_transitions() {
+  map<string, LCTransition>& get_noncur_transitions() {
     return noncur_transitions;
   }
 
@@ -376,8 +357,8 @@ struct transition_action
 {
   int days;
   boost::optional<ceph::real_time> date;
-  int storage_class;
-  transition_action() : days(0), storage_class(standard_ia) {}
+  string storage_class;
+  transition_action() : days(0) {}
 };
 
 struct lc_op
@@ -389,8 +370,8 @@ struct lc_op
   int mp_expiration;
   boost::optional<ceph::real_time> expiration_date;
   boost::optional<RGWObjTags> obj_tags;
-  map<int, transition_action> transitions;
-  map<int, transition_action> noncur_transitions;
+  map<string, transition_action> transitions;
+  map<string, transition_action> noncur_transitions;
   lc_op() : status(false), dm_expiration(false), expiration(0), noncur_expiration(0), mp_expiration(0) {}
   
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -229,86 +229,85 @@ public:
   LCRule(){};
   ~LCRule(){};
 
-  bool get_id(string& _id) {
-      _id = id;
-      return true;
+  const string& get_id() const {
+      return id;
   }
 
-  string& get_status() {
+  const string& get_status() const {
       return status;
   }
 
-  string& get_prefix() {
+  const string& get_prefix() const {
       return prefix;
   }
 
-  LCFilter& get_filter() {
+  const LCFilter& get_filter() const {
     return filter;
   }
 
-  LCExpiration& get_expiration() {
+  const LCExpiration& get_expiration() const {
     return expiration;
   }
 
-  LCExpiration& get_noncur_expiration() {
+  const LCExpiration& get_noncur_expiration() const {
     return noncur_expiration;
   }
 
-  LCExpiration& get_mp_expiration() {
+  const LCExpiration& get_mp_expiration() const {
     return mp_expiration;
   }
 
-  bool get_dm_expiration() {
+  bool get_dm_expiration() const {
     return dm_expiration;
   }
 
-  map<string, LCTransition>& get_transitions() {
+  const map<string, LCTransition>& get_transitions() const {
     return transitions;
   }
 
-  map<string, LCTransition>& get_noncur_transitions() {
+  const map<string, LCTransition>& get_noncur_transitions() const {
     return noncur_transitions;
   }
 
-  void set_id(string*_id) {
-    id = *_id;
+  void set_id(const string& _id) {
+    id = _id;
   }
 
-  void set_prefix(string*_prefix) {
-    prefix = *_prefix;
+  void set_prefix(const string& _prefix) {
+    prefix = _prefix;
   }
 
-  void set_status(string*_status) {
-    status = *_status;
+  void set_status(const string& _status) {
+    status = _status;
   }
 
-  void set_expiration(LCExpiration*_expiration) {
-    expiration = *_expiration;
+  void set_expiration(const LCExpiration& _expiration) {
+    expiration = _expiration;
   }
 
-  void set_noncur_expiration(LCExpiration*_noncur_expiration) {
-    noncur_expiration = *_noncur_expiration;
+  void set_noncur_expiration(const LCExpiration& _noncur_expiration) {
+    noncur_expiration = _noncur_expiration;
   }
 
-  void set_mp_expiration(LCExpiration* _mp_expiration) {
-    mp_expiration = *_mp_expiration;
+  void set_mp_expiration(const LCExpiration& _mp_expiration) {
+    mp_expiration = _mp_expiration;
   }
 
   void set_dm_expiration(bool _dm_expiration) {
     dm_expiration = _dm_expiration;
   }
 
-  bool add_transition(LCTransition* _transition) {
-    auto ret = transitions.emplace(_transition->get_storage_class(), *_transition);
+  bool add_transition(const LCTransition& _transition) {
+    auto ret = transitions.emplace(_transition.get_storage_class(), _transition);
     return ret.second;
   }
 
-  bool add_noncur_transition(LCTransition* _noncur_transition) {
-    auto ret = noncur_transitions.emplace(_noncur_transition->get_storage_class(), *_noncur_transition);
+  bool add_noncur_transition(const LCTransition& _noncur_transition) {
+    auto ret = noncur_transitions.emplace(_noncur_transition.get_storage_class(), _noncur_transition);
     return ret.second;
   }
 
-  bool valid();
+  bool valid() const;
   
   void encode(bufferlist& bl) const {
      ENCODE_START(6, 1, bl);
@@ -383,7 +382,7 @@ protected:
   CephContext *cct;
   map<string, lc_op> prefix_map;
   multimap<string, LCRule> rule_map;
-  bool _add_rule(LCRule *rule);
+  bool _add_rule(const LCRule& rule);
   bool has_same_action(const lc_op& first, const lc_op& second);
 public:
   explicit RGWLifecycleConfiguration(CephContext *_cct) : cct(_cct) {}
@@ -408,16 +407,16 @@ public:
     multimap<string, LCRule>::iterator iter;
     for (iter = rule_map.begin(); iter != rule_map.end(); ++iter) {
       LCRule& rule = iter->second;
-      _add_rule(&rule);
+      _add_rule(rule);
     }
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
   static void generate_test_instances(list<RGWLifecycleConfiguration*>& o);
 
-  void add_rule(LCRule* rule);
+  void add_rule(const LCRule& rule);
 
-  int check_and_add_rule(LCRule* rule);
+  int check_and_add_rule(const LCRule& rule);
 
   bool valid();
 

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -24,77 +24,100 @@ static bool check_date(const string& _date)
   return true;
 }
 
-bool LCExpiration_S3::xml_end(const char * el) {
-  LCDays_S3 *lc_days = static_cast<LCDays_S3 *>(find_first("Days"));
-  LCDeleteMarker_S3 *lc_dm = static_cast<LCDeleteMarker_S3 *>(find_first("ExpiredObjectDeleteMarker"));
-  LCDate_S3 *lc_date = static_cast<LCDate_S3 *>(find_first("Date"));
-
-  if ((!lc_days && !lc_dm && !lc_date) || (lc_days && lc_dm) 
-      || (lc_days && lc_date) || (lc_dm && lc_date)) {
-    return false;
-  }
-  if (lc_days) {
-    days = lc_days->get_data();
-  } else if (lc_dm) {
-    dm_expiration = lc_dm->get_data().compare("true") == 0;
-    if (!dm_expiration) {
-      return false;
-    }
+void LCExpiration_S3::dump_xml(Formatter *f) const {
+  if (dm_expiration) {
+    encode_xml("ExpiredObjectDeleteMarker", "true", f);
+  } else if (!days.empty()) {
+    encode_xml("Days", days, f);
   } else {
-    date = lc_date->get_data();
+    encode_xml("Date", date, f);
+  }
+}
+
+void LCExpiration_S3::decode_xml(XMLObj *obj)
+{
+  bool has_days = RGWXMLDecoder::decode_xml("Days", days, obj);
+  bool has_date = RGWXMLDecoder::decode_xml("Date", date, obj);
+  string dm;
+  bool has_dm = RGWXMLDecoder::decode_xml("ExpiredObjectDeleteMarker", dm, obj);
+
+  if ((!has_days && !has_dm && !has_date) || (has_days && has_dm) 
+      || (has_days && has_date) || (has_dm && has_date)) {
+    throw RGWXMLDecoder::err("bad Expiration section");
+  }
+
+  if (has_date && !check_date(date)) {
     //We need return xml error according to S3
-    if (!check_date(date)) {
-      return false;
-    }
+    throw RGWXMLDecoder::err("bad date in Date section");
   }
-  return true;
 }
 
-bool LCNoncurExpiration_S3::xml_end(const char *el) {
-  LCDays_S3 *lc_noncur_days = static_cast<LCDays_S3 *>(find_first("NoncurrentDays"));
-  if (!lc_noncur_days) {
-    return false;
-  }
-  days = lc_noncur_days->get_data();
-  return true;
+void LCNoncurExpiration_S3::decode_xml(XMLObj *obj)
+{
+  RGWXMLDecoder::decode_xml("NoncurrentDays", days, obj, true);
 }
 
-bool LCMPExpiration_S3::xml_end(const char *el) {
-  LCDays_S3 *lc_mp_days = static_cast<LCDays_S3 *>(find_first("DaysAfterInitiation"));
-  if (!lc_mp_days) {
-    return false;
-  }
-  days = lc_mp_days->get_data();
-  return true;
+void LCNoncurExpiration_S3::dump_xml(Formatter *f) const
+{
+  encode_xml("NoncurrentDays", days, f);
 }
 
-bool RGWLifecycleConfiguration_S3::xml_end(const char *el) {
-  XMLObjIter iter = find("Rule");
-  LCRule_S3 *rule = static_cast<LCRule_S3 *>(iter.get_next());
-  if (!rule)
-    return false;
-  while (rule) {
-    add_rule(rule);
-    rule = static_cast<LCRule_S3 *>(iter.get_next());
+void LCMPExpiration_S3::decode_xml(XMLObj *obj)
+{
+  RGWXMLDecoder::decode_xml("DaysAfterInitiation", days, obj, true);
+}
+
+void LCMPExpiration_S3::dump_xml(Formatter *f) const
+{
+  encode_xml("DaysAfterInitiation", days, f);
+}
+
+void RGWLifecycleConfiguration_S3::decode_xml(XMLObj *obj)
+{
+  vector<LCRule_S3> rules;
+
+  RGWXMLDecoder::decode_xml("Rule", rules, obj, true);
+
+  for (auto& rule : rules) {
+    add_rule(&rule);
   }
+
   if (cct->_conf->rgw_lc_max_rules < rule_map.size()) {
-    ldout(cct, 5) << "Warn: The lifecycle config has too many rules, rule number is:" 
-                  << rule_map.size() << ", max number is:" << cct->_conf->rgw_lc_max_rules << dendl;
-    return false;
+    stringstream ss;
+    ss << "Warn: The lifecycle config has too many rules, rule number is:" 
+      << rule_map.size() << ", max number is:" << cct->_conf->rgw_lc_max_rules;
+    throw RGWXMLDecoder::err(ss.str());
   }
-  return true;
 }
 
-bool LCFilter_S3::xml_end(const char* el) {
+void LCFilter_S3::dump_xml(Formatter *f) const
+{
+  if (has_prefix()) {
+    encode_xml("Prefix", prefix, f);
+  }
+  bool multi = has_multi_condition();
+  if (multi) {
+    f->open_array_section("And");
+  }
+  if (has_tags()) {
+    const auto& tagset_s3 = static_cast<const RGWObjTagSet_S3 &>(obj_tags);
+    tagset_s3.dump_xml(f);
+  }
+  if (multi) {
+    f->close_section();
+  }
+}
 
-  XMLObj *o = find_first("And");
+void LCFilter_S3::decode_xml(XMLObj *obj)
+{
+  XMLObj *o = obj->find_first("And");
   bool single_cond = false;
   int num_conditions = 0;
   // If there is an AND condition, every tag is a child of and
   // else we only support single conditions and return false if we see multiple
 
   if (o == nullptr){
-    o = this;
+    o = obj;
     single_cond = true;
   }
 
@@ -111,65 +134,56 @@ bool LCFilter_S3::xml_end(const char* el) {
     num_conditions++;
   }
 
-  return !(single_cond && num_conditions > 1);
+  if (single_cond && num_conditions > 1) {
+    throw RGWXMLDecoder::err("Bad filter: badly formed multiple conditions");
+  }
 }
 
-bool LCTransition_S3::xml_end(const char* el) {
-  LCDays_S3 *lc_days = static_cast<LCDays_S3 *>(find_first("Days"));
-  LCDate_S3 *lc_date = static_cast<LCDate_S3 *>(find_first("Date"));
-  if ((lc_days && lc_date) || (!lc_days && !lc_date)) {
-    return false;
+void LCTransition_S3::decode_xml(XMLObj *obj)
+{
+  bool has_days = RGWXMLDecoder::decode_xml("Days", days, obj);
+  bool has_date = RGWXMLDecoder::decode_xml("Date", date, obj);
+  if ((has_days && has_date) || (!has_days && !has_date)) {
+    throw RGWXMLDecoder::err("bad Transition section");
   }
-  if (lc_days) {
-    days = lc_days->get_data();
-  } else {
-    date = lc_date->get_data();
+
+  if (has_date && !check_date(date)) {
     //We need return xml error according to S3
-    if (!check_date(date)) {
-      return false;
-    }
+    throw RGWXMLDecoder::err("bad Date in Transition section");
   }
-  LCStorageClass_S3 *lc_storage_class = static_cast<LCStorageClass_S3 *>(find_first("StorageClass"));
-  if (!lc_storage_class) {
-    return false;
+
+  if (!RGWXMLDecoder::decode_xml("StorageClass", storage_class, obj)) {
+    throw RGWXMLDecoder::err("missing StorageClass in Transition section");
   }
-  storage_class = lc_storage_class->get_data();
-  if (storage_class.compare("STANDARD_IA") != 0 && storage_class.compare("ONEZONE_IA") != 0 &&
-      storage_class.compare("GLACIER") != 0) {
-    return false;
-  }
-  return true;
 }
 
-bool LCNoncurTransition_S3::xml_end(const char* el) {
-  LCDays_S3 *lc_noncur_days = static_cast<LCDays_S3 *>(find_first("NoncurrentDays"));
-  if (!lc_noncur_days) {
-    return false;
+void LCTransition_S3::dump_xml(Formatter *f) const {
+  if (!days.empty()) {
+    encode_xml("Days", days, f);
+  } else {
+    encode_xml("Date", date, f);
   }
-  days = lc_noncur_days->get_data();
-  LCStorageClass_S3 *lc_storage_class = static_cast<LCStorageClass_S3 *>(find_first("StorageClass"));
-  if (!lc_storage_class) {
-    return false;
-  }
-  storage_class = lc_storage_class->get_data();
-  if (storage_class.compare("STANDARD_IA") != 0 && storage_class.compare("ONEZONE_IA") != 0 &&
-      storage_class.compare("GLACIER") != 0) {
-    return false;
-  }
-  return true;
+  encode_xml("StorageClass", storage_class, f);
 }
 
+void LCNoncurTransition_S3::decode_xml(XMLObj *obj)
+{
+  if (!RGWXMLDecoder::decode_xml("NoncurrentDays", days, obj)) {
+    throw RGWXMLDecoder::err("missing NoncurrentDays in NoncurrentVersionTransition section");
+  }
+  if (!RGWXMLDecoder::decode_xml("StorageClass", storage_class, obj)) {
+    throw RGWXMLDecoder::err("missing StorageClass in NoncurrentVersionTransition section");
+  }
+}
 
-bool LCRule_S3::xml_end(const char *el) {
-  LCID_S3 *lc_id;
-  LCPrefix_S3 *lc_prefix;
-  LCStatus_S3 *lc_status;
-  LCExpiration_S3 *lc_expiration;
-  LCNoncurExpiration_S3 *lc_noncur_expiration;
-  LCMPExpiration_S3 *lc_mp_expiration;
-  LCFilter_S3 *lc_filter;
-  LCTransition_S3 *lc_transition;
-  LCNoncurTransition_S3 *lc_noncur_transition;
+void LCNoncurTransition_S3::dump_xml(Formatter *f) const
+{
+  encode_xml("NoncurrentDays", days, f);
+  encode_xml("StorageClass", storage_class, f);
+}
+
+void LCRule_S3::decode_xml(XMLObj *obj)
+{
   id.clear();
   prefix.clear();
   status.clear();
@@ -178,19 +192,12 @@ bool LCRule_S3::xml_end(const char *el) {
   // S3 generates a 48 bit random ID, maybe we could generate shorter IDs
   static constexpr auto LC_ID_LENGTH = 48;
 
-  lc_id = static_cast<LCID_S3 *>(find_first("ID"));
-  if (lc_id){
-    id = lc_id->get_data();
-  } else {
+  if (!RGWXMLDecoder::decode_xml("ID", id, obj)) {
     gen_rand_alphanumeric_lower(cct, &id, LC_ID_LENGTH);
   }
 
-
-  lc_filter = static_cast<LCFilter_S3 *>(find_first("Filter"));
-
-  if (lc_filter){
-    filter = *lc_filter;
-  } else {
+  LCFilter_S3 filter_s3;
+  if (!RGWXMLDecoder::decode_xml("Filter", filter_s3, obj)) {
     // Ideally the following code should be deprecated and we should return
     // False here, The new S3 LC configuration xml spec. makes Filter mandatory
     // and Prefix optional. However older clients including boto2 still generate
@@ -199,101 +206,103 @@ bool LCRule_S3::xml_end(const char *el) {
     // argument. A day will come when S3 enforces their own xml-spec, but it is
     // not this day
 
-    lc_prefix = static_cast<LCPrefix_S3 *>(find_first("Prefix"));
-
-    if (!lc_prefix){
-      return false;
+    if (!RGWXMLDecoder::decode_xml("Prefix", prefix, obj)) {
+      throw RGWXMLDecoder::err("missing Prefix in Filter");
     }
+  }
+  filter = (LCFilter)filter_s3;
 
-    prefix = lc_prefix->get_data();
+  if (!RGWXMLDecoder::decode_xml("Status", status, obj)) {
+    throw RGWXMLDecoder::err("missing Status in Filter");
+  }
+  if (status.compare("Enabled") != 0 && status.compare("Disabled") != 0) {
+    throw RGWXMLDecoder::err("bad Status in Filter");
   }
 
 
-  lc_status = static_cast<LCStatus_S3 *>(find_first("Status"));
-  if (!lc_status)
-    return false;
-  status = lc_status->get_data();
-  if (status.compare("Enabled") != 0 && status.compare("Disabled") != 0)
-    return false;
+  LCExpiration_S3 s3_expiration;
+  LCExpiration_S3 s3_noncur_expiration;
+  LCExpiration_S3 s3_mp_expiration;
+  LCFilter_S3 s3_filter;
 
-  lc_expiration = static_cast<LCExpiration_S3 *>(find_first("Expiration"));
-  lc_noncur_expiration = static_cast<LCNoncurExpiration_S3 *>(find_first("NoncurrentVersionExpiration"));
-  lc_mp_expiration = static_cast<LCMPExpiration_S3 *>(find_first("AbortIncompleteMultipartUpload"));
+  bool has_expiration = RGWXMLDecoder::decode_xml("Expiration", s3_expiration, obj);
+  bool has_noncur_expiration = RGWXMLDecoder::decode_xml("NoncurrentVersionExpiration", s3_noncur_expiration, obj);
+  bool has_mp_expiration = RGWXMLDecoder::decode_xml("AbortIncompleteMultipartUpload", s3_mp_expiration, obj);
 
-  XMLObjIter iter = find("Transition");
-  lc_transition = static_cast<LCTransition_S3 *>(iter.get_next());
-  XMLObjIter noncur_iter = find("NoncurrentVersionTransition");
-  lc_noncur_transition = static_cast<LCNoncurTransition_S3 *>(noncur_iter.get_next());
+  vector<LCTransition_S3> transitions;
+  vector<LCNoncurTransition_S3> noncur_transitions;
 
-  if (!lc_expiration && !lc_noncur_expiration && !lc_mp_expiration && !lc_transition && !lc_noncur_transition) {
-    return false;
-  } else {
-    if (lc_expiration) {
-      if (lc_expiration->has_days()) {
-        expiration.set_days(lc_expiration->get_days_str());
-      } else if (lc_expiration->has_date()) {
-        expiration.set_date(lc_expiration->get_date());
-      } else {
-        dm_expiration = lc_expiration->get_dm_expiration();
-      }
-    }
-    if (lc_noncur_expiration) {
-      noncur_expiration = *lc_noncur_expiration;
-    }
-    if (lc_mp_expiration) {
-      mp_expiration = *lc_mp_expiration;
-    }
-    while (lc_transition) {
-      if (!add_transition(lc_transition)) {
-        return false;
-      }
-      lc_transition = static_cast<LCTransition_S3 *>(iter.get_next());
-    }
-    while (lc_noncur_transition) {
-      if (!add_noncur_transition(lc_noncur_transition)) {
-        return false;
-      }
-      lc_noncur_transition = static_cast<LCNoncurTransition_S3 *>(noncur_iter.get_next());
+  bool has_transition = RGWXMLDecoder::decode_xml("Transition", transitions, obj);
+  bool has_noncur_transition = RGWXMLDecoder::decode_xml("NoncurrentVersionTransition", noncur_transitions, obj);
+
+  if (!has_expiration &&
+      !has_noncur_expiration &&
+      !has_mp_expiration &&
+      !has_transition &&
+      !has_noncur_transition) {
+    throw RGWXMLDecoder::err("bad Rule");
+  }
+
+  if (has_expiration) {
+    if (s3_expiration.has_days() ||
+        s3_expiration.has_date()) {
+      expiration = s3_expiration;
+    } else {
+      dm_expiration = s3_expiration.get_dm_expiration();
     }
   }
-  return true;
+  if (has_noncur_expiration) {
+    noncur_expiration = s3_noncur_expiration;
+  }
+  if (has_mp_expiration) {
+    mp_expiration = s3_mp_expiration;
+  }
+  for (auto& t : transitions) {
+    if (!add_transition(&t)) {
+      throw RGWXMLDecoder::err("Failed to add transition");
+    }
+  }
+  for (auto& t : noncur_transitions) {
+    if (!add_noncur_transition(&t)) {
+      throw RGWXMLDecoder::err("Failed to add non-current version transition");
+    }
+  }
 }
 
-void LCRule_S3::to_xml(ostream& out) {
-  out << "<Rule>" ;
-  out << "<ID>" << id << "</ID>";
+void LCRule_S3::dump_xml(Formatter *f) const {
+  encode_xml("ID", id, f);
+  // In case of an empty filter and an empty Prefix, we defer to Prefix.
   if (!filter.empty()) {
-    LCFilter_S3& lc_filter = static_cast<LCFilter_S3&>(filter);
-    lc_filter.to_xml(out);
+    const LCFilter_S3& lc_filter = static_cast<const LCFilter_S3&>(filter);
+    encode_xml("Filter", lc_filter, f);
   } else {
-    out << "<Prefix>" << prefix << "</Prefix>";
+    encode_xml("Prefix", prefix, f);
   }
-  out << "<Status>" << status << "</Status>";
+  encode_xml("Status", status, f);
   if (!expiration.empty() || dm_expiration) {
     LCExpiration_S3 expir(expiration.get_days_str(), expiration.get_date(), dm_expiration);
-    expir.to_xml(out);
+    encode_xml("Expiration", expir, f);
   }
   if (!noncur_expiration.empty()) {
-    LCNoncurExpiration_S3& noncur_expir = static_cast<LCNoncurExpiration_S3&>(noncur_expiration);
-    noncur_expir.to_xml(out);
+    const LCNoncurExpiration_S3& noncur_expir = static_cast<const LCNoncurExpiration_S3&>(noncur_expiration);
+    encode_xml("NoncurrentVersionExpiration", noncur_expir, f);
   }
   if (!mp_expiration.empty()) {
-    LCMPExpiration_S3& mp_expir = static_cast<LCMPExpiration_S3&>(mp_expiration);
-    mp_expir.to_xml(out);
+    const LCMPExpiration_S3& mp_expir = static_cast<const LCMPExpiration_S3&>(mp_expiration);
+    encode_xml("AbortIncompleteMultipartUpload", mp_expir, f);
   }
   if (!transitions.empty()) {
     for (auto &elem : transitions) {
-      LCTransition_S3& tran = static_cast<LCTransition_S3&>(elem.second);
-      tran.to_xml(out);
+      const LCTransition_S3& tran = static_cast<const LCTransition_S3&>(elem.second);
+      encode_xml("Transition", tran, f);
     }
   }
   if (!noncur_transitions.empty()) {
     for (auto &elem : noncur_transitions) {
-      LCNoncurTransition_S3& noncur_tran = static_cast<LCNoncurTransition_S3&>(elem.second);
-      noncur_tran.to_xml(out);
+      const LCNoncurTransition_S3& noncur_tran = static_cast<const LCNoncurTransition_S3&>(elem.second);
+      encode_xml("NoncurrentVersionTransition", noncur_tran, f);
     }
   }
-  out << "</Rule>";
 }
 
 int RGWLifecycleConfiguration_S3::rebuild(RGWRados *store, RGWLifecycleConfiguration& dest)
@@ -313,58 +322,11 @@ int RGWLifecycleConfiguration_S3::rebuild(RGWRados *store, RGWLifecycleConfigura
 }
 
 
-
 void RGWLifecycleConfiguration_S3::dump_xml(Formatter *f) const
 {
-	f->open_object_section_in_ns("LifecycleConfiguration", XMLNS_AWS_S3);
-
-    for (auto iter = rule_map.begin(); iter != rule_map.end(); ++iter) {
-		const LCRule_S3& rule = static_cast<const LCRule_S3&>(iter->second);
-		rule.dump_xml(f);
-	}
-
-	f->close_section(); // Lifecycle
-}
-
-XMLObj *RGWLCXMLParser_S3::alloc_obj(const char *el)
-{
-  XMLObj * obj = NULL;
-  if (strcmp(el, "LifecycleConfiguration") == 0) {
-    obj = new RGWLifecycleConfiguration_S3(cct);
-  } else if (strcmp(el, "Rule") == 0) {
-    obj = new LCRule_S3(cct);
-  } else if (strcmp(el, "ID") == 0) {
-    obj = new LCID_S3();
-  } else if (strcmp(el, "Prefix") == 0) {
-    obj = new LCPrefix_S3();
-  } else if (strcmp(el, "Filter") == 0) {
-    obj = new LCFilter_S3();
-  } else if (strcmp(el, "Status") == 0) {
-    obj = new LCStatus_S3();
-  } else if (strcmp(el, "Expiration") == 0) {
-    obj = new LCExpiration_S3();
-  } else if (strcmp(el, "Days") == 0) {
-    obj = new LCDays_S3();
-  } else if (strcmp(el, "Date") == 0) {
-    obj = new LCDate_S3();
-  } else if (strcmp(el, "ExpiredObjectDeleteMarker") == 0) {
-    obj = new LCDeleteMarker_S3();
-  } else if (strcmp(el, "NoncurrentVersionExpiration") == 0) {
-    obj = new LCNoncurExpiration_S3();
-  } else if (strcmp(el, "NoncurrentDays") == 0) {
-    obj = new LCDays_S3();
-  } else if (strcmp(el, "AbortIncompleteMultipartUpload") == 0) {
-    obj = new LCMPExpiration_S3();
-  } else if (strcmp(el, "DaysAfterInitiation") == 0) {
-    obj = new LCDays_S3();
-  } else if (strcmp(el, "StorageClass") == 0) {
-    obj = new LCStorageClass_S3();
-  } else if (strcmp(el, "Transition") == 0) {
-    obj = new LCTransition_S3();
-  } else if (strcmp(el, "NoncurrentVersionTransition") == 0) {
-    obj = new LCNoncurTransition_S3();
+  for (auto iter = rule_map.begin(); iter != rule_map.end(); ++iter) {
+    const LCRule_S3& rule = static_cast<const LCRule_S3&>(iter->second);
+    encode_xml("Rule", rule, f);
   }
-  return obj;
 }
-
 

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -355,7 +355,7 @@ XMLObj *RGWLCXMLParser_S3::alloc_obj(const char *el)
   return obj;
 }
 
-bool check_date(const string& _date)
+static bool check_date(const string& _date)
 {
   boost::optional<ceph::real_time> date = ceph::from_iso_8601(_date);
   if (boost::none == date) {

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -41,14 +41,19 @@ void LCExpiration_S3::decode_xml(XMLObj *obj)
   string dm;
   bool has_dm = RGWXMLDecoder::decode_xml("ExpiredObjectDeleteMarker", dm, obj);
 
-  if ((!has_days && !has_dm && !has_date) || (has_days && has_dm) 
-      || (has_days && has_date) || (has_dm && has_date)) {
+  int num = !!has_days + !!has_date + !!has_dm;
+
+  if (num != 1) {
     throw RGWXMLDecoder::err("bad Expiration section");
   }
 
   if (has_date && !check_date(date)) {
     //We need return xml error according to S3
     throw RGWXMLDecoder::err("bad date in Date section");
+  }
+
+  if (has_dm) {
+    dm_expiration = (dm == "true");
   }
 }
 
@@ -74,12 +79,25 @@ void LCMPExpiration_S3::dump_xml(Formatter *f) const
 
 void RGWLifecycleConfiguration_S3::decode_xml(XMLObj *obj)
 {
+  if (!cct) {
+    throw RGWXMLDecoder::err("ERROR: RGWLifecycleConfiguration_S3 can't be decoded without cct initialized");
+  }
   vector<LCRule_S3> rules;
 
   RGWXMLDecoder::decode_xml("Rule", rules, obj, true);
 
   for (auto& rule : rules) {
-    add_rule(&rule);
+    if (rule.get_id().empty()) {
+      string id;
+
+      // S3 generates a 48 bit random ID, maybe we could generate shorter IDs
+      static constexpr auto LC_ID_LENGTH = 48;
+
+      gen_rand_alphanumeric_lower(cct, &id, LC_ID_LENGTH);
+      rule.set_id(id);
+    }
+
+    add_rule(rule);
   }
 
   if (cct->_conf->rgw_lc_max_rules < rule_map.size()) {
@@ -189,12 +207,7 @@ void LCRule_S3::decode_xml(XMLObj *obj)
   status.clear();
   dm_expiration = false;
 
-  // S3 generates a 48 bit random ID, maybe we could generate shorter IDs
-  static constexpr auto LC_ID_LENGTH = 48;
-
-  if (!RGWXMLDecoder::decode_xml("ID", id, obj)) {
-    gen_rand_alphanumeric_lower(cct, &id, LC_ID_LENGTH);
-  }
+  RGWXMLDecoder::decode_xml("ID", id, obj);
 
   LCFilter_S3 filter_s3;
   if (!RGWXMLDecoder::decode_xml("Filter", filter_s3, obj)) {
@@ -219,10 +232,9 @@ void LCRule_S3::decode_xml(XMLObj *obj)
     throw RGWXMLDecoder::err("bad Status in Filter");
   }
 
-
   LCExpiration_S3 s3_expiration;
-  LCExpiration_S3 s3_noncur_expiration;
-  LCExpiration_S3 s3_mp_expiration;
+  LCNoncurExpiration_S3 s3_noncur_expiration;
+  LCMPExpiration_S3 s3_mp_expiration;
   LCFilter_S3 s3_filter;
 
   bool has_expiration = RGWXMLDecoder::decode_xml("Expiration", s3_expiration, obj);
@@ -258,12 +270,12 @@ void LCRule_S3::decode_xml(XMLObj *obj)
     mp_expiration = s3_mp_expiration;
   }
   for (auto& t : transitions) {
-    if (!add_transition(&t)) {
+    if (!add_transition(t)) {
       throw RGWXMLDecoder::err("Failed to add transition");
     }
   }
   for (auto& t : noncur_transitions) {
-    if (!add_noncur_transition(&t)) {
+    if (!add_noncur_transition(t)) {
       throw RGWXMLDecoder::err("Failed to add non-current version transition");
     }
   }
@@ -311,7 +323,7 @@ int RGWLifecycleConfiguration_S3::rebuild(RGWRados *store, RGWLifecycleConfigura
   multimap<string, LCRule>::iterator iter;
   for (iter = rule_map.begin(); iter != rule_map.end(); ++iter) {
     LCRule& src_rule = iter->second;
-    ret = dest.check_and_add_rule(&src_rule);
+    ret = dest.check_and_add_rule(src_rule);
     if (ret < 0)
       return ret;
   }

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -11,6 +11,18 @@
 
 #define dout_subsys ceph_subsys_rgw
 
+static bool check_date(const string& _date)
+{
+  boost::optional<ceph::real_time> date = ceph::from_iso_8601(_date);
+  if (boost::none == date) {
+    return false;
+  }
+  struct timespec time = ceph::real_clock::to_timespec(*date);
+  if (time.tv_sec % (24*60*60) || time.tv_nsec) {
+    return false;
+  }
+  return true;
+}
 
 bool LCExpiration_S3::xml_end(const char * el) {
   LCDays_S3 *lc_days = static_cast<LCDays_S3 *>(find_first("Days"));
@@ -355,15 +367,4 @@ XMLObj *RGWLCXMLParser_S3::alloc_obj(const char *el)
   return obj;
 }
 
-static bool check_date(const string& _date)
-{
-  boost::optional<ceph::real_time> date = ceph::from_iso_8601(_date);
-  if (boost::none == date) {
-    return false;
-  }
-  struct timespec time = ceph::real_clock::to_timespec(*date);
-  if (time.tv_sec % (24*60*60) || time.tv_nsec) {
-    return false;
-  }
-  return true;
-}
+

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -327,5 +327,4 @@ public:
   void dump_xml(Formatter *f) const;
 };
 
-bool check_date(const string& _date);
 #endif

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -11,134 +11,23 @@
 #include "rgw_xml.h"
 #include "rgw_tag_s3.h"
 
-class LCID_S3 : public XMLObj
+class LCFilter_S3 : public LCFilter
 {
 public:
-  LCID_S3() {}
-  ~LCID_S3() override {}
-  string& to_str() { return data; }
+  void dump_xml(Formatter *f) const;
+  void decode_xml(XMLObj *obj);
 };
 
-class LCPrefix_S3 : public XMLObj
-{
-public:
-  LCPrefix_S3() {}
-  ~LCPrefix_S3() override {}
-  string& to_str() { return data; }
-};
-
-class LCFilter_S3 : public LCFilter, public XMLObj
-{
- public:
-  ~LCFilter_S3() override {}
-  string& to_str() { return data; }
-  void to_xml(ostream& out){
-    out << "<Filter>";
-    stringstream ss;
-    if (has_prefix())
-      out << "<Prefix>" << prefix << "</Prefix>";
-    if (has_tags()){
-      for (const auto&kv : obj_tags.get_tags()){
-        ss << "<Tag>";
-        ss << "<Key>" << kv.first << "</Key>";
-        ss << "<Value>" << kv.second << "</Value>";
-        ss << "</Tag>";
-      }
-    }
-
-    if (has_multi_condition()) {
-      out << "<And>" << ss.str() << "</And>";
-    } else {
-      out << ss.str();
-    }
-
-    out << "</Filter>";
-  }
-  void dump_xml(Formatter *f) const {
-    f->open_object_section("Filter");
-    if (has_multi_condition())
-      f->open_object_section("And");
-    if (!prefix.empty())
-      encode_xml("Prefix", prefix, f);
-    if (has_tags()){
-      const auto& tagset_s3 = static_cast<const RGWObjTagSet_S3 &>(obj_tags);
-      tagset_s3.dump_xml(f);
-    }
-    if (has_multi_condition())
-      f->close_section(); // And;
-    f->close_section(); // Filter
-  }
-  bool xml_end(const char *el) override;
-};
-
-class LCStatus_S3 : public XMLObj
-{
-public:
-  LCStatus_S3() {}
-  ~LCStatus_S3() override {}
-  string& to_str() { return data; }
-};
-
-class LCDays_S3 : public XMLObj
-{
-public:
-  LCDays_S3() {}
-  ~LCDays_S3() override {}
-  string& to_str() { return data; }
-};
-
-class LCDate_S3 : public XMLObj
-{
-public:
-  LCDate_S3() {}
-  ~LCDate_S3() override {}
-  string& to_str() { return data; }
-};
-
-class LCDeleteMarker_S3 : public XMLObj
-{
-public:
-  LCDeleteMarker_S3() {}
-  ~LCDeleteMarker_S3() override {}
-  string& to_str() { return data; }
-};
-
-class LCExpiration_S3 : public LCExpiration, public XMLObj
+class LCExpiration_S3 : public LCExpiration
 {
 private:
-  bool dm_expiration;
+  bool dm_expiration{false};
 public:
-  LCExpiration_S3(): dm_expiration(false) {}
-  LCExpiration_S3(string _days, string _date, bool _dm_expiration) {
-    days = _days;
-    date = _date;
-    dm_expiration = _dm_expiration;
-  }
-  ~LCExpiration_S3() override {}
+  LCExpiration_S3() {}
+  LCExpiration_S3(string _days, string _date, bool _dm_expiration) : LCExpiration(_days, _date), dm_expiration(_dm_expiration) {}
 
-  bool xml_end(const char *el) override;
-  void to_xml(ostream& out) {
-    out << "<Expiration>";
-    if (dm_expiration) {
-      out << "<ExpiredObjectDeleteMarker>" << "true" << "</ExpiredObjectDeleteMarker>";
-    } else if (!days.empty()){
-      out << "<Days>" << days << "</Days>";
-    } else {
-      out << "<Date>" << date << "</Date>";
-    }
-    out << "</Expiration>";
-  }
-  void dump_xml(Formatter *f) const {
-    f->open_object_section("Expiration");
-    if (dm_expiration) {
-      encode_xml("ExpiredObjectDeleteMarker", "true", f);
-    } else if (!days.empty()) {
-      encode_xml("Days", days, f);
-    } else {
-      encode_xml("Date", date, f);
-    }
-    f->close_section(); // Expiration
-  }
+  void dump_xml(Formatter *f) const;
+  void decode_xml(XMLObj *obj);
 
   void set_dm_expiration(bool _dm_expiration) {
     dm_expiration = _dm_expiration;
@@ -149,180 +38,67 @@ public:
   }
 };
 
-class LCNoncurExpiration_S3 : public LCExpiration, public XMLObj
+class LCNoncurExpiration_S3 : public LCExpiration
 {
 public:
   LCNoncurExpiration_S3() {}
-  ~LCNoncurExpiration_S3() override {}
   
-  bool xml_end(const char *el) override;
-  void to_xml(ostream& out) {
-    out << "<NoncurrentVersionExpiration>" << "<NoncurrentDays>" << days << "</NoncurrentDays>"<< "</NoncurrentVersionExpiration>";
-  }
-  void dump_xml(Formatter *f) const {
-    f->open_object_section("NoncurrentVersionExpiration");
-    encode_xml("NoncurrentDays", days, f);
-    f->close_section(); 
-  }
+  void decode_xml(XMLObj *obj);
+  void dump_xml(Formatter *f) const;
 };
 
-class LCMPExpiration_S3 : public LCExpiration, public XMLObj
+class LCMPExpiration_S3 : public LCExpiration
 {
 public:
   LCMPExpiration_S3() {}
-  ~LCMPExpiration_S3() {}
 
-  bool xml_end(const char *el) override;
-  void to_xml(ostream& out) {
-    out << "<AbortIncompleteMultipartUpload>" << "<DaysAfterInitiation>" << days << "</DaysAfterInitiation>" << "</AbortIncompleteMultipartUpload>";
-  }
-  void dump_xml(Formatter *f) const {
-    f->open_object_section("AbortIncompleteMultipartUpload");
-    encode_xml("DaysAfterInitiation", days, f);
-    f->close_section();
-  }
+  void decode_xml(XMLObj *obj);
+  void dump_xml(Formatter *f) const;
 };
 
-class LCStorageClass_S3 : public XMLObj
-{
-public:
-  LCStorageClass_S3() {}
-  ~LCStorageClass_S3() override {}
-  string& to_str() { return data; }
-};
-
-class LCTransition_S3 : public LCTransition, public XMLObj
+class LCTransition_S3 : public LCTransition
 {
 public:
   LCTransition_S3() {}
-  ~LCTransition_S3() {}
 
-  bool xml_end(const char *el) override;
-  void to_xml(ostream& out) {
-    out << "<Transition>";
-    if (!days.empty()) {
-      out << "<Days>" << days << "</Days>";
-    } else {
-      out << "<Date>" << date << "</Date>";
-    }
-    out << "<StorageClass>" << storage_class << "</StorageClass>" << "</Transition>";
-  }
-
-  void dump_xml(Formatter *f) const {
-    f->open_object_section("Transition");
-    if (!days.empty()) {
-      encode_xml("Days", days, f);
-    } else {
-      encode_xml("Date", date, f);
-    }
-    encode_xml("StorageClass", storage_class, f);
-    f->close_section();
-  }
+  void decode_xml(XMLObj *obj);
+  void dump_xml(Formatter *f) const;
 };
 
-class LCNoncurTransition_S3 : public LCTransition, public XMLObj
+class LCNoncurTransition_S3 : public LCTransition
 {
 public:
   LCNoncurTransition_S3() {}
   ~LCNoncurTransition_S3() {}
 
-  bool xml_end(const char *el) override;
-  void to_xml(ostream& out) {
-    out << "<NoncurrentVersionTransition>" << "<NoncurrentDays>" << days << "</NoncurrentDays>"
-        << "<StorageClass>" << storage_class << "</StorageClass>" << "</NoncurrentVersionTransition>";
-  }
-
-  void dump_xml(Formatter *f) const {
-    f->open_object_section("NoncurrentVersionTransition");
-    encode_xml("NoncurrentDays", days, f);
-    encode_xml("StorageClass", storage_class, f);
-    f->close_section();
-  }
+  void decode_xml(XMLObj *obj);
+  void dump_xml(Formatter *f) const;
 };
 
 
-class LCRule_S3 : public LCRule, public XMLObj
+class LCRule_S3 : public LCRule
 {
 private:
   CephContext *cct;
 public:
   LCRule_S3(): cct(nullptr) {}
   explicit LCRule_S3(CephContext *_cct): cct(_cct) {}
-  ~LCRule_S3() override {}
 
-  void to_xml(ostream& out);
-  bool xml_end(const char *el) override;
-  bool xml_start(const char *el, const char **attr);
-  void dump_xml(Formatter *f) const {
-    f->open_object_section("Rule");
-    encode_xml("ID", id, f);
-    // In case of an empty filter and an empty Prefix, we defer to Prefix.
-    if (!filter.empty()) {
-      const LCFilter_S3& lc_filter = static_cast<const LCFilter_S3&>(filter);
-      lc_filter.dump_xml(f);
-    } else {
-      encode_xml("Prefix", prefix, f);
-    }
-    encode_xml("Status", status, f);
-    if (!expiration.empty() || dm_expiration) {
-      LCExpiration_S3 expir(expiration.get_days_str(), expiration.get_date(), dm_expiration);
-      expir.dump_xml(f);
-    }
-    if (!noncur_expiration.empty()) {
-      const LCNoncurExpiration_S3& noncur_expir = static_cast<const LCNoncurExpiration_S3&>(noncur_expiration);
-      noncur_expir.dump_xml(f);
-    }
-    if (!mp_expiration.empty()) {
-      const LCMPExpiration_S3& mp_expir = static_cast<const LCMPExpiration_S3&>(mp_expiration);
-      mp_expir.dump_xml(f);
-    }
-    if (!transitions.empty()) {
-      for (auto &elem : transitions) {
-        const LCTransition_S3& tran = static_cast<const LCTransition_S3&>(elem.second);
-        tran.dump_xml(f);
-      }
-    }
-    if (!noncur_transitions.empty()) {
-      for (auto &elem : noncur_transitions) {
-        const LCNoncurTransition_S3& noncur_tran = static_cast<const LCNoncurTransition_S3&>(elem.second);
-        noncur_tran.dump_xml(f);
-      }
-    }
-    f->close_section(); // Rule
-  }
+  void dump_xml(Formatter *f) const;
+  void decode_xml(XMLObj *obj);
 
   void set_ctx(CephContext *ctx) {
     cct = ctx;
   }
 };
 
-class RGWLCXMLParser_S3 : public RGWXMLParser
-{
-  CephContext *cct;
-
-  XMLObj *alloc_obj(const char *el) override;
-public:
-  explicit RGWLCXMLParser_S3(CephContext *_cct) : cct(_cct) {}
-};
-
-class RGWLifecycleConfiguration_S3 : public RGWLifecycleConfiguration, public XMLObj
+class RGWLifecycleConfiguration_S3 : public RGWLifecycleConfiguration
 {
 public:
   explicit RGWLifecycleConfiguration_S3(CephContext *_cct) : RGWLifecycleConfiguration(_cct) {}
-  RGWLifecycleConfiguration_S3() : RGWLifecycleConfiguration(NULL) {}
-  ~RGWLifecycleConfiguration_S3() override {}
+  RGWLifecycleConfiguration_S3() : RGWLifecycleConfiguration(nullptr) {}
 
-  bool xml_end(const char *el) override;
-
-  void to_xml(ostream& out) {
-    out << "<LifecycleConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">";
-    multimap<string, LCRule>::iterator iter;
-    for (iter = rule_map.begin(); iter != rule_map.end(); ++iter) {
-      LCRule_S3& rule = static_cast<LCRule_S3&>(iter->second);
-      rule.to_xml(out);
-    }
-    out << "</LifecycleConfiguration>";
-  }
+  void decode_xml(XMLObj *obj);
   int rebuild(RGWRados *store, RGWLifecycleConfiguration& dest);
   void dump_xml(Formatter *f) const;
 };

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -78,18 +78,11 @@ public:
 
 class LCRule_S3 : public LCRule
 {
-private:
-  CephContext *cct;
 public:
-  LCRule_S3(): cct(nullptr) {}
-  explicit LCRule_S3(CephContext *_cct): cct(_cct) {}
+  LCRule_S3() {}
 
   void dump_xml(Formatter *f) const;
   void decode_xml(XMLObj *obj);
-
-  void set_ctx(CephContext *ctx) {
-    cct = ctx;
-  }
 };
 
 class RGWLifecycleConfiguration_S3 : public RGWLifecycleConfiguration

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -544,6 +544,13 @@ int rgw_build_bucket_policies(RGWRados* store, struct req_state* s)
         return -ERR_PERMANENT_REDIRECT;
       }
     }
+
+    /* init dest placement -- only if bucket exists, otherwise request is either not relevant, or
+     * it's a create_bucket request, in which case the op will deal with the placement later */
+    if (s->bucket_exists) {
+      s->dest_placement.storage_class = s->info.storage_class;
+      s->dest_placement.inherit_from(s->bucket_info.placement_rule);
+    }
   }
 
   /* handle user ACL only for those APIs which support it */
@@ -3477,7 +3484,7 @@ void RGWPutObj::execute()
 
   if (multipart) {
     processor.emplace<MultipartObjectProcessor>(
-        &aio, store, s->bucket_info, &s->info.storage_class,
+        &aio, store, s->bucket_info, &s->dest_placement,
         s->owner.get_id(), obj_ctx, obj,
         multipart_upload_id, multipart_part_num, multipart_part_str);
   } else {
@@ -3490,7 +3497,7 @@ void RGWPutObj::execute()
       }
     }
     processor.emplace<AtomicObjectProcessor>(
-        &aio, store, s->bucket_info, &s->info.storage_class,
+        &aio, store, s->bucket_info, &s->dest_placement,
         s->bucket_owner.get_id(), obj_ctx, obj, olh_epoch, s->req_id);
   }
 
@@ -3808,12 +3815,10 @@ void RGWPostObj::execute()
       store->gen_rand_obj_instance_name(&obj);
     }
 
-    rgw_placement_rule& tail_placement = s->info.storage_class;
-
     using namespace rgw::putobj;
     AioThrottle aio(s->cct->_conf->rgw_put_obj_min_window_size);
     AtomicObjectProcessor processor(&aio, store, s->bucket_info,
-                                    &tail_placement,
+                                    &s->dest_placement,
                                     s->bucket_owner.get_id(),
                                     *static_cast<RGWObjectCtx*>(s->obj_ctx),
                                     obj, 0, s->req_id);
@@ -4661,8 +4666,6 @@ void RGWCopyObj::execute()
     return;
   }
 
-  rgw_placement_rule& dest_placement = s->info.storage_class;
-
   op_ret = store->copy_obj(obj_ctx,
 			   s->user->user_id,
 			   &s->info,
@@ -4671,7 +4674,7 @@ void RGWCopyObj::execute()
 			   src_obj,
 			   dest_bucket_info,
 			   src_bucket_info,
-                           &dest_placement,
+                           s->dest_placement,
 			   &src_mtime,
 			   &mtime,
 			   mod_ptr,
@@ -6412,6 +6415,7 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
     pmaster_num_shards = nullptr;
   }
 
+  rgw_placement_rule placement_rule(binfo.placement_rule, s->info.storage_class);
 
   if (bucket_exists) {
     rgw_placement_rule selected_placement_rule;
@@ -6420,7 +6424,7 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
     bucket.name = s->bucket_name;
     op_ret = store->svc.zone->select_bucket_placement(*(s->user),
                                             store->svc.zone->get_zonegroup().get_id(),
-                                            s->info.storage_class,
+                                            placement_rule,
                                             &selected_placement_rule,
                                             nullptr);
     if (selected_placement_rule != binfo.placement_rule) {
@@ -6450,7 +6454,7 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
   op_ret = store->create_bucket(*(s->user),
                                 bucket,
                                 store->svc.zone->get_zonegroup().get_id(),
-                                s->info.storage_class, binfo.swift_ver_location,
+                                placement_rule, binfo.swift_ver_location,
                                 pquota_info, attrs,
                                 out_info, pobjv, &ep_objv, creation_time,
                                 pmaster_bucket, pmaster_num_shards, true);
@@ -6586,12 +6590,10 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
     store->gen_rand_obj_instance_name(&obj);
   }
 
-  rgw_placement_rule& tail_placement = s->info.storage_class;
-
   using namespace rgw::putobj;
   AioThrottle aio(store->ctx()->_conf->rgw_put_obj_min_window_size);
 
-  AtomicObjectProcessor processor(&aio, store, binfo, &tail_placement, bowner.get_id(),
+  AtomicObjectProcessor processor(&aio, store, binfo, &s->dest_placement, bowner.get_id(),
                                   obj_ctx, obj, 0, s->req_id);
 
   op_ret = processor.prepare();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3477,7 +3477,8 @@ void RGWPutObj::execute()
 
   if (multipart) {
     processor.emplace<MultipartObjectProcessor>(
-        &aio, store, s->bucket_info, s->owner.get_id(), obj_ctx, obj,
+        &aio, store, s->bucket_info, &s->info.storage_class,
+        s->owner.get_id(), obj_ctx, obj,
         multipart_upload_id, multipart_part_num, multipart_part_str);
   } else {
     if (s->bucket_info.versioning_enabled()) {
@@ -3489,8 +3490,8 @@ void RGWPutObj::execute()
       }
     }
     processor.emplace<AtomicObjectProcessor>(
-        &aio, store, s->bucket_info, s->bucket_owner.get_id(),
-        obj_ctx, obj, olh_epoch, s->req_id);
+        &aio, store, s->bucket_info, &s->info.storage_class,
+        s->bucket_owner.get_id(), obj_ctx, obj, olh_epoch, s->req_id);
   }
 
   op_ret = processor->prepare();
@@ -3802,16 +3803,17 @@ void RGWPostObj::execute()
       ldpp_dout(this, 15) << "supplied_md5=" << supplied_md5 << dendl;
     }
 
-
     rgw_obj obj(s->bucket, get_current_filename());
     if (s->bucket_info.versioning_enabled()) {
       store->gen_rand_obj_instance_name(&obj);
     }
 
+    rgw_placement_rule& tail_placement = s->info.storage_class;
+
     using namespace rgw::putobj;
     AioThrottle aio(s->cct->_conf->rgw_put_obj_min_window_size);
     AtomicObjectProcessor processor(&aio, store, s->bucket_info,
-                                    nullptr,
+                                    &tail_placement,
                                     s->bucket_owner.get_id(),
                                     *static_cast<RGWObjectCtx*>(s->obj_ctx),
                                     obj, 0, s->req_id);
@@ -6409,8 +6411,6 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
   }
 
 
-  rgw_placement_rule placement_rule;
-  placement_rule.storage_class = s->info.storage_class;
   if (bucket_exists) {
     rgw_placement_rule selected_placement_rule;
     rgw_bucket bucket;
@@ -6418,7 +6418,7 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
     bucket.name = s->bucket_name;
     op_ret = store->svc.zone->select_bucket_placement(*(s->user),
                                             store->svc.zone->get_zonegroup().get_id(),
-                                            placement_rule,
+                                            s->info.storage_class,
                                             &selected_placement_rule,
                                             nullptr);
     if (selected_placement_rule != binfo.placement_rule) {
@@ -6448,7 +6448,7 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
   op_ret = store->create_bucket(*(s->user),
                                 bucket,
                                 store->svc.zone->get_zonegroup().get_id(),
-                                placement_rule, binfo.swift_ver_location,
+                                s->info.storage_class, binfo.swift_ver_location,
                                 pquota_info, attrs,
                                 out_info, pobjv, &ep_objv, creation_time,
                                 pmaster_bucket, pmaster_num_shards, true);
@@ -6584,10 +6584,12 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
     store->gen_rand_obj_instance_name(&obj);
   }
 
+  rgw_placement_rule& tail_placement = s->info.storage_class;
+
   using namespace rgw::putobj;
   AioThrottle aio(store->ctx()->_conf->rgw_put_obj_min_window_size);
 
-  AtomicObjectProcessor processor(&aio, store, binfo, nullptr, bowner.get_id(),
+  AtomicObjectProcessor processor(&aio, store, binfo, &tail_placement, bowner.get_id(),
                                   obj_ctx, obj, 0, s->req_id);
 
   op_ret = processor.prepare();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3832,7 +3832,7 @@ void RGWPostObj::execute()
       filter = encrypt.get();
     } else {
       const auto& compression_type = store->svc.zone->get_zone_params().get_compression_type(
-          s->bucket_info.placement_rule.name);
+          s->bucket_info.placement_rule);
       if (compression_type != "none") {
         plugin = Compressor::create(s->cct, compression_type);
         if (!plugin) {
@@ -6599,9 +6599,8 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
   /* No filters by default. */
   DataProcessor *filter = &processor;
 
-#warning add storage_class compression
   const auto& compression_type = store->svc.zone->get_zone_params().get_compression_type(
-      binfo.placement_rule.name);
+      binfo.placement_rule);
   CompressorRef plugin;
   boost::optional<RGWPutObj_Compress> compressor;
   if (compression_type != "none") {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -659,6 +659,11 @@ int rgw_build_bucket_policies(RGWRados* store, struct req_state* s)
     if (s->bucket_exists) {
       s->dest_placement.storage_class = s->info.storage_class;
       s->dest_placement.inherit_from(s->bucket_info.placement_rule);
+
+      if (!store->svc.zone->get_zone_params().valid_placement(s->dest_placement)) {
+        ldpp_dout(s, 0) << "NOTICE: invalid dest placement: " << s->dest_placement.to_str() << dendl;
+        return -EINVAL;
+      }
     }
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5086,7 +5086,7 @@ void RGWPutLC::execute()
 {
   bufferlist bl;
   
-  RGWLifecycleConfiguration_S3 config;
+  RGWLifecycleConfiguration_S3 config(s->cct);
   RGWXMLParser parser;
   RGWLifecycleConfiguration_S3 new_config(s->cct);
 
@@ -5145,7 +5145,7 @@ void RGWPutLC::execute()
     RGWXMLDecoder::decode_xml("LifecycleConfiguration", config, &parser);
   } catch (RGWXMLDecoder::err& err) {
     ldpp_dout(this, 5) << "Bad lifecycle configuration: " << err << dendl;
-    op_ret = -EINVAL;
+    op_ret = -ERR_MALFORMED_XML;
     return;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -306,7 +306,7 @@ static vector<Policy> get_iam_user_policy_from_attr(CephContext* cct,
   return policies;
 }
 
-static int get_obj_attrs(RGWRados *store, struct req_state *s, rgw_obj& obj, map<string, bufferlist>& attrs)
+static int get_obj_attrs(RGWRados *store, struct req_state *s, const rgw_obj& obj, map<string, bufferlist>& attrs)
 {
   RGWRados::Object op_target(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), obj);
   RGWRados::Object::Read read_op(&op_target);
@@ -316,7 +316,116 @@ static int get_obj_attrs(RGWRados *store, struct req_state *s, rgw_obj& obj, map
   return read_op.prepare();
 }
 
-static int modify_obj_attr(RGWRados *store, struct req_state *s, rgw_obj& obj, const char* attr_name, bufferlist& attr_val)
+static int get_obj_head(RGWRados *store, struct req_state *s,
+                        const rgw_obj& obj,
+                        map<string, bufferlist> *attrs,
+                         bufferlist *pbl)
+{
+  store->set_prefetch_data(s->obj_ctx, obj);
+
+  RGWRados::Object op_target(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), obj);
+  RGWRados::Object::Read read_op(&op_target);
+
+  read_op.params.attrs = attrs;
+
+  int ret = read_op.prepare();
+  if (ret < 0) {
+    return ret;
+  }
+
+  if (!pbl) {
+    return 0;
+  }
+
+  ret = read_op.read(0, s->cct->_conf->rgw_max_chunk_size, *pbl);
+
+  return 0;
+}
+
+struct multipart_upload_info
+{
+  rgw_placement_rule dest_placement;
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(dest_placement, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(dest_placement, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(multipart_upload_info)
+
+static int get_multipart_info(RGWRados *store, struct req_state *s,
+			      const rgw_obj& obj,
+                              RGWAccessControlPolicy *policy,
+			      map<string, bufferlist> *attrs,
+                              multipart_upload_info *upload_info)
+{
+  bufferlist header;
+
+  bufferlist headbl;
+  bufferlist *pheadbl = (upload_info ? &headbl : nullptr);
+
+  int op_ret = get_obj_head(store, s, obj, attrs, pheadbl);
+  if (op_ret < 0) {
+    if (op_ret == -ENOENT) {
+      return -ERR_NO_SUCH_UPLOAD;
+    }
+    return op_ret;
+  }
+
+  if (upload_info && headbl.length() > 0) {
+    auto hiter = headbl.cbegin();
+    try {
+      decode(*upload_info, hiter);
+    } catch (buffer::error& err) {
+      ldpp_dout(s, 0) << "ERROR: failed to decode multipart upload info" << dendl;
+      return -EIO;
+    }
+  }
+
+  if (policy && attrs) {
+    for (auto& iter : *attrs) {
+      string name = iter.first;
+      if (name.compare(RGW_ATTR_ACL) == 0) {
+        bufferlist& bl = iter.second;
+        auto bli = bl.cbegin();
+        try {
+          decode(*policy, bli);
+        } catch (buffer::error& err) {
+          ldpp_dout(s, 0) << "ERROR: could not decode policy" << dendl;
+          return -EIO;
+        }
+        break;
+      }
+    }
+  }
+
+  return 0;
+}
+
+static int get_multipart_info(RGWRados *store, struct req_state *s,
+			      string& meta_oid,
+                              RGWAccessControlPolicy *policy,
+			      map<string, bufferlist> *attrs,
+                              multipart_upload_info *upload_info)
+{
+  map<string, bufferlist>::iterator iter;
+  bufferlist header;
+
+  rgw_obj meta_obj;
+  meta_obj.init_ns(s->bucket, meta_oid, mp_ns);
+  meta_obj.set_in_extra_data(true);
+
+  return get_multipart_info(store, s, meta_obj, policy, attrs, upload_info);
+}
+
+static int modify_obj_attr(RGWRados *store, struct req_state *s, const rgw_obj& obj, const char* attr_name, bufferlist& attr_val)
 {
   map<string, bufferlist> attrs;
   RGWRados::Object op_target(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), obj);
@@ -3483,8 +3592,21 @@ void RGWPutObj::execute()
   ceph::static_ptr<ObjectProcessor, max_processor_size> processor;
 
   if (multipart) {
+    RGWMPObj mp(s->object.name, multipart_upload_id);
+
+    multipart_upload_info upload_info;
+    op_ret = get_multipart_info(store, s, mp.get_meta(), nullptr, nullptr, &upload_info);
+    if (op_ret < 0) {
+      if (op_ret != -ENOENT) {
+        ldpp_dout(this, 0) << "ERROR: get_multipart_info returned " << op_ret << ": " << cpp_strerror(-op_ret) << dendl;
+      } else {// -ENOENT: raced with upload complete/cancel, no need to spam log
+        ldpp_dout(this, 20) << "failed to get multipart info (returned " << op_ret << ": " << cpp_strerror(-op_ret) << "): probably raced with upload complete / cancel" << dendl;
+      }
+      return;
+    }
+    ldpp_dout(this, 20) << "dest_placement for part=" << upload_info.dest_placement << dendl;
     processor.emplace<MultipartObjectProcessor>(
-        &aio, store, s->bucket_info, &s->dest_placement,
+        &aio, store, s->bucket_info, &upload_info.dest_placement,
         s->owner.get_id(), obj_ctx, obj,
         multipart_upload_id, multipart_part_num, multipart_part_str);
   } else {
@@ -5372,48 +5494,15 @@ void RGWInitMultipart::execute()
     obj_op.meta.category = RGW_OBJ_CATEGORY_MULTIMETA;
     obj_op.meta.flags = PUT_OBJ_CREATE_EXCL;
 
-    op_ret = obj_op.write_meta(0, 0, attrs);
+    multipart_upload_info upload_info;
+    upload_info.dest_placement = s->dest_placement;
+
+    bufferlist bl;
+    encode(upload_info, bl);
+    obj_op.meta.data = &bl;
+
+    op_ret = obj_op.write_meta(bl.length(), 0, attrs);
   } while (op_ret == -EEXIST);
-}
-
-static int get_multipart_info(RGWRados *store, struct req_state *s,
-			      string& meta_oid,
-                              RGWAccessControlPolicy *policy,
-			      map<string, bufferlist>& attrs)
-{
-  map<string, bufferlist>::iterator iter;
-  bufferlist header;
-
-  rgw_obj obj;
-  obj.init_ns(s->bucket, meta_oid, mp_ns);
-  obj.set_in_extra_data(true);
-
-  int op_ret = get_obj_attrs(store, s, obj, attrs);
-  if (op_ret < 0) {
-    if (op_ret == -ENOENT) {
-      return -ERR_NO_SUCH_UPLOAD;
-    }
-    return op_ret;
-  }
-
-  if (policy) {
-    for (iter = attrs.begin(); iter != attrs.end(); ++iter) {
-      string name = iter->first;
-      if (name.compare(RGW_ATTR_ACL) == 0) {
-        bufferlist& bl = iter->second;
-        auto bli = bl.cbegin();
-        try {
-          decode(*policy, bli);
-        } catch (buffer::error& err) {
-          ldpp_dout(s, 0) << "ERROR: could not decode policy" << dendl;
-          return -EIO;
-        }
-        break;
-      }
-    }
-  }
-
-  return 0;
 }
 
 int RGWCompleteMultipart::verify_permission()
@@ -5785,7 +5874,6 @@ void RGWAbortMultipart::execute()
   string upload_id;
   string meta_oid;
   upload_id = s->info.args.get("uploadId");
-  map<string, bufferlist> attrs;
   rgw_obj meta_obj;
   RGWMPObj mp;
 
@@ -5795,7 +5883,7 @@ void RGWAbortMultipart::execute()
   mp.init(s->object.name, upload_id);
   meta_oid = mp.get_meta();
 
-  op_ret = get_multipart_info(store, s, meta_oid, NULL, attrs);
+  op_ret = get_multipart_info(store, s, meta_oid, nullptr, nullptr, nullptr);
   if (op_ret < 0)
     return;
 
@@ -5818,7 +5906,6 @@ void RGWListMultipart::pre_exec()
 
 void RGWListMultipart::execute()
 {
-  map<string, bufferlist> xattrs;
   string meta_oid;
   RGWMPObj mp;
 
@@ -5829,7 +5916,7 @@ void RGWListMultipart::execute()
   mp.init(s->object.name, upload_id);
   meta_oid = mp.get_meta();
 
-  op_ret = get_multipart_info(store, s, meta_oid, &policy, xattrs);
+  op_ret = get_multipart_info(store, s, meta_oid, &policy, nullptr, nullptr);
   if (op_ret < 0)
     return;
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3801,6 +3801,7 @@ void RGWPostObj::execute()
       ldpp_dout(this, 15) << "supplied_md5=" << supplied_md5 << dendl;
     }
 
+
     rgw_obj obj(s->bucket, get_current_filename());
     if (s->bucket_info.versioning_enabled()) {
       store->gen_rand_obj_instance_name(&obj);
@@ -3809,6 +3810,7 @@ void RGWPostObj::execute()
     using namespace rgw::putobj;
     AioThrottle aio(s->cct->_conf->rgw_put_obj_min_window_size);
     AtomicObjectProcessor processor(&aio, store, s->bucket_info,
+                                    nullptr,
                                     s->bucket_owner.get_id(),
                                     *static_cast<RGWObjectCtx*>(s->obj_ctx),
                                     obj, 0, s->req_id);
@@ -4664,6 +4666,7 @@ void RGWCopyObj::execute()
 			   src_obj,
 			   dest_bucket_info,
 			   src_bucket_info,
+                           nullptr, /* dest placement rule */
 			   &src_mtime,
 			   &mtime,
 			   mod_ptr,
@@ -6582,7 +6585,7 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
   using namespace rgw::putobj;
   AioThrottle aio(store->ctx()->_conf->rgw_put_obj_min_window_size);
 
-  AtomicObjectProcessor processor(&aio, store, binfo, bowner.get_id(),
+  AtomicObjectProcessor processor(&aio, store, binfo, nullptr, bowner.get_id(),
                                   obj_ctx, obj, 0, s->req_id);
 
   op_ret = processor.prepare();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5086,8 +5086,8 @@ void RGWPutLC::execute()
 {
   bufferlist bl;
   
-  RGWLifecycleConfiguration_S3 *config = NULL;
-  RGWLCXMLParser_S3 parser(s->cct);
+  RGWLifecycleConfiguration_S3 config;
+  RGWXMLParser parser;
   RGWLifecycleConfiguration_S3 new_config(s->cct);
 
   content_md5 = s->info.env->get("HTTP_CONTENT_MD5");
@@ -5140,20 +5140,25 @@ void RGWPutLC::execute()
     op_ret = -ERR_MALFORMED_XML;
     return;
   }
-  config = static_cast<RGWLifecycleConfiguration_S3 *>(parser.find_first("LifecycleConfiguration"));
-  if (!config) {
-    op_ret = -ERR_MALFORMED_XML;
+
+  try {
+    RGWXMLDecoder::decode_xml("LifecycleConfiguration", config, &parser);
+  } catch (RGWXMLDecoder::err& err) {
+    ldpp_dout(this, 5) << "Bad lifecycle configuration: " << err << dendl;
+    op_ret = -EINVAL;
     return;
   }
 
-  op_ret = config->rebuild(store, new_config);
+  op_ret = config.rebuild(store, new_config);
   if (op_ret < 0)
     return;
 
   if (s->cct->_conf->subsys.should_gather<ceph_subsys_rgw, 15>()) {
-    ldpp_dout(this, 15) << "New LifecycleConfiguration:";
-    new_config.to_xml(*_dout);
-    *_dout << dendl;
+    XMLFormatter xf;
+    new_config.dump_xml(&xf);
+    stringstream ss;
+    xf.flush(ss);
+    ldpp_dout(this, 15) << "New LifecycleConfiguration:" << ss.str() << dendl;
   }
   
   new_config.encode(bl);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4661,6 +4661,8 @@ void RGWCopyObj::execute()
     return;
   }
 
+  rgw_placement_rule& dest_placement = s->info.storage_class;
+
   op_ret = store->copy_obj(obj_ctx,
 			   s->user->user_id,
 			   &s->info,
@@ -4669,7 +4671,7 @@ void RGWCopyObj::execute()
 			   src_obj,
 			   dest_bucket_info,
 			   src_bucket_info,
-                           nullptr, /* dest placement rule */
+                           &dest_placement,
 			   &src_mtime,
 			   &mtime,
 			   mod_ptr,

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1657,6 +1657,7 @@ protected:
   int marker;
   RGWAccessControlPolicy policy;
   bool truncated;
+  multipart_upload_info upload_info;
 
 public:
   RGWListMultipart() {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -883,7 +883,7 @@ class RGWCreateBucket : public RGWOp {
 protected:
   RGWAccessControlPolicy policy;
   string location_constraint;
-  string placement_rule;
+  rgw_placement_rule placement_rule;
   RGWBucketInfo info;
   obj_version ep_objv;
   bool has_cors;
@@ -1181,7 +1181,7 @@ protected:
   uint32_t policy_rw_mask;
   RGWAccessControlPolicy policy;
   RGWCORSConfiguration cors_config;
-  string placement_rule;
+  rgw_placement_rule placement_rule;
   boost::optional<std::string> swift_ver_location;
 
 public:

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1881,7 +1881,8 @@ static inline int rgw_get_request_metadata(CephContext* const cct,
   static const std::set<std::string> blacklisted_headers = {
       "x-amz-server-side-encryption-customer-algorithm",
       "x-amz-server-side-encryption-customer-key",
-      "x-amz-server-side-encryption-customer-key-md5"
+      "x-amz-server-side-encryption-customer-key-md5",
+      "x-amz-storage-class"
   };
 
   size_t valid_meta_count = 0;

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -209,7 +209,7 @@ int AtomicObjectProcessor::prepare()
 
   r = manifest_gen.create_begin(store->ctx(), &manifest,
                                 bucket_info.placement_rule,
-                                ptail_placement_rule,
+                                &tail_placement_rule,
                                 head_obj.bucket, head_obj);
   if (r < 0) {
     return r;
@@ -329,7 +329,7 @@ int MultipartObjectProcessor::prepare_head()
 {
   int r = manifest_gen.create_begin(store->ctx(), &manifest,
                                     bucket_info.placement_rule,
-                                    ptail_placement_rule,
+                                    &tail_placement_rule,
                                     target_obj.bucket, target_obj);
   if (r < 0) {
     return r;

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -209,6 +209,7 @@ int AtomicObjectProcessor::prepare()
 
   r = manifest_gen.create_begin(store->ctx(), &manifest,
                                 bucket_info.placement_rule,
+                                ptail_placement_rule,
                                 head_obj.bucket, head_obj);
   if (r < 0) {
     return r;
@@ -328,6 +329,7 @@ int MultipartObjectProcessor::prepare_head()
 {
   int r = manifest_gen.create_begin(store->ctx(), &manifest,
                                     bucket_info.placement_rule,
+                                    ptail_placement_rule,
                                     target_obj.bucket, target_obj);
   if (r < 0) {
     return r;

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -111,7 +111,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
  protected:
   RGWRados *const store;
   const RGWBucketInfo& bucket_info;
-  const rgw_placement_rule *ptail_placement_rule;
+  rgw_placement_rule tail_placement_rule;
   const rgw_user& owner;
   RGWObjectCtx& obj_ctx;
   rgw_obj head_obj;
@@ -133,11 +133,14 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
                           const rgw_obj& head_obj)
     : HeadObjectProcessor(0),
       store(store), bucket_info(bucket_info),
-      ptail_placement_rule(ptail_placement_rule), owner(owner),
+      owner(owner),
       obj_ctx(obj_ctx), head_obj(head_obj),
       writer(aio, store, bucket_info, obj_ctx, head_obj),
-      chunk(&writer, 0), stripe(&chunk, this, 0)
-  {}
+      chunk(&writer, 0), stripe(&chunk, this, 0) {
+        if (ptail_placement_rule) {
+          tail_placement_rule = *ptail_placement_rule;
+        }
+      }
 };
 
 

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -111,7 +111,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
  protected:
   RGWRados *const store;
   const RGWBucketInfo& bucket_info;
-  const string *ptail_placement_rule;
+  const rgw_placement_rule *ptail_placement_rule;
   const rgw_user& owner;
   RGWObjectCtx& obj_ctx;
   rgw_obj head_obj;
@@ -128,7 +128,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
  public:
   ManifestObjectProcessor(Aio *aio, RGWRados *store,
                           const RGWBucketInfo& bucket_info,
-                          const string *ptail_placement_rule,
+                          const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,
                           const rgw_obj& head_obj)
     : HeadObjectProcessor(0),
@@ -152,7 +152,7 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
  public:
   AtomicObjectProcessor(Aio *aio, RGWRados *store,
                         const RGWBucketInfo& bucket_info,
-                        const string *ptail_placement_rule,
+                        const rgw_placement_rule *ptail_placement_rule,
                         const rgw_user& owner,
                         RGWObjectCtx& obj_ctx, const rgw_obj& head_obj,
                         std::optional<uint64_t> olh_epoch,
@@ -193,7 +193,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
  public:
   MultipartObjectProcessor(Aio *aio, RGWRados *store,
                            const RGWBucketInfo& bucket_info,
-                           const string *ptail_placement_rule,
+                           const rgw_placement_rule *ptail_placement_rule,
                            const rgw_user& owner, RGWObjectCtx& obj_ctx,
                            const rgw_obj& head_obj,
                            const std::string& upload_id, uint64_t part_num,

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -111,6 +111,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
  protected:
   RGWRados *const store;
   const RGWBucketInfo& bucket_info;
+  const string *ptail_placement_rule;
   const rgw_user& owner;
   RGWObjectCtx& obj_ctx;
   rgw_obj head_obj;
@@ -127,10 +128,12 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
  public:
   ManifestObjectProcessor(Aio *aio, RGWRados *store,
                           const RGWBucketInfo& bucket_info,
+                          const string *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,
                           const rgw_obj& head_obj)
     : HeadObjectProcessor(0),
-      store(store), bucket_info(bucket_info), owner(owner),
+      store(store), bucket_info(bucket_info),
+      ptail_placement_rule(ptail_placement_rule), owner(owner),
       obj_ctx(obj_ctx), head_obj(head_obj),
       writer(aio, store, bucket_info, obj_ctx, head_obj),
       chunk(&writer, 0), stripe(&chunk, this, 0)
@@ -148,11 +151,14 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
   int process_first_chunk(bufferlist&& data, DataProcessor **processor) override;
  public:
   AtomicObjectProcessor(Aio *aio, RGWRados *store,
-                        const RGWBucketInfo& bucket_info, const rgw_user& owner,
+                        const RGWBucketInfo& bucket_info,
+                        const string *ptail_placement_rule,
+                        const rgw_user& owner,
                         RGWObjectCtx& obj_ctx, const rgw_obj& head_obj,
                         std::optional<uint64_t> olh_epoch,
                         const std::string& unique_tag)
-    : ManifestObjectProcessor(aio, store, bucket_info, owner, obj_ctx, head_obj),
+    : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
+                              owner, obj_ctx, head_obj),
       olh_epoch(olh_epoch), unique_tag(unique_tag)
   {}
 
@@ -187,11 +193,13 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
  public:
   MultipartObjectProcessor(Aio *aio, RGWRados *store,
                            const RGWBucketInfo& bucket_info,
+                           const string *ptail_placement_rule,
                            const rgw_user& owner, RGWObjectCtx& obj_ctx,
                            const rgw_obj& head_obj,
                            const std::string& upload_id, uint64_t part_num,
                            const std::string& part_num_str)
-    : ManifestObjectProcessor(aio, store, bucket_info, owner, obj_ctx, head_obj),
+    : ManifestObjectProcessor(aio, store, bucket_info, ptail_placement_rule,
+                              owner, obj_ctx, head_obj),
       target_obj(head_obj), upload_id(upload_id),
       part_num(part_num), part_num_str(part_num_str),
       mp(head_obj.key.name, upload_id)

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -186,6 +186,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
   const std::string upload_id;
   const int part_num;
   const std::string part_num_str;
+  multipart_upload_info upload_info;
   RGWMPObj mp;
 
   // write the first chunk and wait on aio->drain() for its completion.

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -307,12 +307,19 @@ void RGWObjManifest::obj_iterator::operator++()
   update_location();
 }
 
-int RGWObjManifest::generator::create_begin(CephContext *cct, RGWObjManifest *_m, const string& placement_rule, const rgw_bucket& _b, const rgw_obj& _obj)
+int RGWObjManifest::generator::create_begin(CephContext *cct, RGWObjManifest *_m,
+                                            const string& head_placement_rule,
+                                            const string *tail_placement_rule,
+                                            const rgw_bucket& _b, const rgw_obj& _obj)
 {
   manifest = _m;
 
-  manifest->set_tail_placement(placement_rule, _b);
-  manifest->set_head(placement_rule, _obj, 0);
+  if (!tail_placement_rule) {
+    tail_placement_rule = &head_placement_rule;
+  }
+
+  manifest->set_tail_placement(*tail_placement_rule, _b);
+  manifest->set_head(head_placement_rule, _obj, 0);
   last_ofs = 0;
 
   if (manifest->get_prefix().empty()) {
@@ -3391,6 +3398,7 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
                obj,
                dest_bucket_info,
                bucket_info,
+               nullptr, /* const string *tail_rule */
                NULL, /* time_t *src_mtime */
                NULL, /* time_t *mtime */
                NULL, /* const time_t *mod_ptr */
@@ -3477,6 +3485,7 @@ int RGWRados::swift_versioning_restore(RGWSysObjectCtx& sysobj_ctx,
                        archive_obj,   /* src obj */
                        bucket_info,   /* dest bucket info */
                        archive_binfo, /* src bucket info */
+                       nullptr,       /* const string *ptail_rule */
                        nullptr,       /* time_t *src_mtime */
                        nullptr,       /* time_t *mtime */
                        nullptr,       /* const time_t *mod_ptr */
@@ -4031,7 +4040,7 @@ int RGWRados::rewrite_obj(RGWBucketInfo& dest_bucket_info, const rgw_obj& obj)
   attrset.erase(RGW_ATTR_ID_TAG);
   attrset.erase(RGW_ATTR_TAIL_TAG);
 
-  return copy_obj_data(rctx, dest_bucket_info, read_op, obj_size - 1, obj, NULL, mtime, attrset,
+  return copy_obj_data(rctx, dest_bucket_info, nullptr, read_op, obj_size - 1, obj, NULL, mtime, attrset,
                        0, real_time(), NULL);
 }
 
@@ -4281,7 +4290,9 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
   using namespace rgw::putobj;
   AioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
-  AtomicObjectProcessor processor(&aio, this, dest_bucket_info, user_id,
+  string *ptail_rule{nullptr};
+#warning FIXME ptail_rule
+  AtomicObjectProcessor processor(&aio, this, dest_bucket_info, ptail_rule, user_id,
                                   obj_ctx, dest_obj, olh_epoch, tag);
   int ret = processor.prepare();
   if (ret < 0) {
@@ -4536,6 +4547,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
                rgw_obj& src_obj,
                RGWBucketInfo& dest_bucket_info,
                RGWBucketInfo& src_bucket_info,
+               const string *ptail_rule,
                real_time *src_mtime,
                real_time *mtime,
                const real_time *mod_ptr,
@@ -4648,11 +4660,27 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
 
   rgw_pool src_pool;
   rgw_pool dest_pool;
-  if (!get_obj_data_pool(src_bucket_info.placement_rule, src_obj, &src_pool)) {
+
+  const string *src_rule{nullptr};
+
+  if (astate->has_manifest) {
+    src_rule = &astate->manifest.get_tail_placement().placement_rule;
+  }
+
+  if (!src_rule || src_rule->empty()) {
+    src_rule = &src_bucket_info.placement_rule;
+  }
+
+  if (!ptail_rule) {
+    ptail_rule = &dest_bucket_info.placement_rule;
+  }
+
+  if (!get_obj_data_pool(*src_rule, src_obj, &src_pool)) {
     ldout(cct, 0) << "ERROR: failed to locate data pool for " << src_obj << dendl;
     return -EIO;
   }
-  if (!get_obj_data_pool(dest_bucket_info.placement_rule, dest_obj, &dest_pool)) {
+
+  if (!get_obj_data_pool(*ptail_rule, dest_obj, &dest_pool)) {
     ldout(cct, 0) << "ERROR: failed to locate data pool for " << dest_obj << dendl;
     return -EIO;
   }
@@ -4690,7 +4718,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   }
 
   if (copy_data) { /* refcounting tail wouldn't work here, just copy the data */
-    return copy_obj_data(obj_ctx, dest_bucket_info, read_op, obj_size - 1, dest_obj,
+    return copy_obj_data(obj_ctx, dest_bucket_info, ptail_rule, read_op, obj_size - 1, dest_obj,
                          mtime, real_time(), attrs, olh_epoch, delete_at, petag);
   }
 
@@ -4807,6 +4835,7 @@ done_ret:
 
 int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
                RGWBucketInfo& dest_bucket_info,
+               const string *ptail_rule,
 	       RGWRados::Object::Read& read_op, off_t end,
                const rgw_obj& dest_obj,
 	       real_time *mtime,
@@ -4821,7 +4850,7 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
 
   using namespace rgw::putobj;
   AioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
-  AtomicObjectProcessor processor(&aio, this, dest_bucket_info,
+  AtomicObjectProcessor processor(&aio, this, dest_bucket_info, ptail_rule,
                                   dest_bucket_info.owner, obj_ctx,
                                   dest_obj, olh_epoch, tag);
   int ret = processor.prepare();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4676,6 +4676,11 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     ptail_rule = &dest_bucket_info.placement_rule;
   }
 
+  auto& dest_storage_class = ptail_rule->get_storage_class();
+  bufferlist scbl;
+  scbl.append(dest_storage_class);
+  attrs[RGW_ATTR_STORAGE_CLASS] = scbl;
+
   if (!get_obj_data_pool(*src_rule, src_obj, &src_pool)) {
     ldout(cct, 0) << "ERROR: failed to locate data pool for " << src_obj << dendl;
     return -EIO;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2907,7 +2907,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
   return -ENOENT;
 }
 
-bool RGWRados::get_obj_data_pool(const string& placement_rule, const rgw_obj& obj, rgw_pool *pool)
+bool RGWRados::get_obj_data_pool(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_pool *pool)
 {
   return rgw_get_obj_data_pool(svc.zone->get_zonegroup(), svc.zone->get_zone_params(), placement_rule, obj, pool);
 }
@@ -4326,9 +4326,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   boost::optional<RGWPutObj_Compress> compressor;
   CompressorRef plugin;
 
-#warning compression type
   const auto& compression_type = svc.zone->get_zone_params().get_compression_type(
-      dest_bucket_info.placement_rule.name);
+      dest_bucket_info.placement_rule);
   if (compression_type != "none") {
     plugin = Compressor::create(cct, compression_type);
     if (!plugin) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6547,6 +6547,12 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
   if (r < 0)
     return r;
 
+  if (astate->size == 0) {
+    end = 0;
+  } else if (end >= (int64_t)astate->size) {
+    end = astate->size - 1;
+  }
+
   if (end < 0)
     len = 0;
   else

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4548,7 +4548,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
                rgw_obj& src_obj,
                RGWBucketInfo& dest_bucket_info,
                RGWBucketInfo& src_bucket_info,
-               const rgw_placement_rule *ptail_rule,
+               rgw_placement_rule *ptail_rule,
                real_time *src_mtime,
                real_time *mtime,
                const real_time *mod_ptr,
@@ -4666,6 +4666,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
 
   if (astate->has_manifest) {
     src_rule = &astate->manifest.get_tail_placement().placement_rule;
+    ldout(cct, 20) << __func__ << "(): manifest src_rule=" << src_rule->to_str() << dendl;
   }
 
   if (!src_rule || src_rule->empty()) {
@@ -4674,6 +4675,8 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
 
   if (!ptail_rule) {
     ptail_rule = &dest_bucket_info.placement_rule;
+  } else {
+    ptail_rule->inherit_from(dest_bucket_info.placement_rule);
   }
 
   auto& dest_storage_class = ptail_rule->get_storage_class();
@@ -4691,6 +4694,8 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     return -EIO;
   }
 
+  ldout(cct, 20) << __func__ << "(): src_rule=" << src_rule->to_str() << " src_pool=" << src_pool
+                             << " dest_rule=" << ptail_rule->to_str() << " dest_pool=" << dest_pool << dendl;
 
   bool copy_data = !astate->has_manifest || (src_pool != dest_pool);
   bool copy_first = false;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6620,6 +6620,7 @@ struct get_obj_data : public RefCountedObject {
   RGWRados *rados;
   RGWObjectCtx *ctx;
   IoCtx io_ctx;
+  rgw_pool cur_pool;
   map<off_t, get_obj_io> io_map;
   map<off_t, librados::AioCompletion *> completion_map;
   uint64_t total_read;
@@ -6913,6 +6914,10 @@ int RGWRados::get_obj_iterate_cb(RGWObjectCtx *ctx, RGWObjState *astate,
       if (!len)
 	  return 0;
     }
+
+    if (d->cur_pool.empty()) {
+      d->cur_pool = read_obj.pool;
+    }
   }
 
   d->throttle.get(len);
@@ -6927,6 +6932,16 @@ int RGWRados::get_obj_iterate_cb(RGWObjectCtx *ctx, RGWObjState *astate,
 
   ldout(cct, 20) << "rados->get_obj_iterate_cb oid=" << read_obj.oid << " obj-ofs=" << obj_ofs << " read_ofs=" << read_ofs << " len=" << len << dendl;
   op.read(read_ofs, len, pbl, NULL);
+
+  /* have we switched to a different pool? */
+  if (read_obj.pool != d->cur_pool) {
+    r = open_pool_ctx(read_obj.pool, d->io_ctx);
+    if (r < 0) {
+      ldout(cct, 0) << "ERROR: " << __func__ << "(): failed to open pool: " << read_obj.pool << " r=" << r << dendl;
+      return r;
+    }
+    d->cur_pool = read_obj.pool;
+  }
 
   librados::IoCtx io_ctx(d->io_ctx);
   io_ctx.locator_set_key(read_obj.loc);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3631,7 +3631,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
     if (name.compare(RGW_ATTR_ETAG) == 0) {
       etag = bl.to_str();
     } else if (name.compare(RGW_ATTR_CONTENT_TYPE) == 0) {
-      content_type = bl.c_str();
+      content_type = bl.to_str();
     } else if (name.compare(RGW_ATTR_ACL) == 0) {
       acl_bl = bl;
     }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3599,6 +3599,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   string etag;
   string content_type;
   bufferlist acl_bl;
+  string storage_class;
 
   map<string, bufferlist>::iterator iter;
   if (meta.rmattrs) {
@@ -3609,6 +3610,8 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   }
 
   if (meta.manifest) {
+    storage_class = meta.manifest->get_tail_placement().placement_rule.storage_class;
+
     /* remove existing manifest attr */
     iter = attrs.find(RGW_ATTR_MANIFEST);
     if (iter != attrs.end())
@@ -3702,7 +3705,8 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
 
   tracepoint(rgw_rados, complete_enter, req_id.c_str());
   r = index_op->complete(poolid, epoch, size, accounted_size,
-                        meta.set_mtime, etag, content_type, &acl_bl,
+                        meta.set_mtime, etag, content_type,
+                        storage_class, &acl_bl,
                         meta.category, meta.remove_objs, meta.user_data);
   tracepoint(rgw_rados, complete_exit, req_id.c_str());
   if (r < 0)
@@ -6187,10 +6191,15 @@ int RGWRados::set_attrs(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& ob
       bufferlist content_type_bl = attrs[RGW_ATTR_CONTENT_TYPE];
       string etag(etag_bl.c_str(), etag_bl.length());
       string content_type(content_type_bl.c_str(), content_type_bl.length());
+      string storage_class;
+      auto iter = attrs.find(RGW_ATTR_STORAGE_CLASS);
+      if (iter != attrs.end()) {
+        storage_class = iter->second.to_str();
+      }
       uint64_t epoch = ref.ioctx.get_last_version();
       int64_t poolid = ref.ioctx.get_id();
       r = index_op.complete(poolid, epoch, state->size, state->accounted_size,
-                            mtime, etag, content_type, &acl_bl,
+                            mtime, etag, content_type, storage_class, &acl_bl,
                             RGW_OBJ_CATEGORY_MAIN, NULL);
     } else {
       int ret = index_op.cancel();
@@ -6412,7 +6421,7 @@ int RGWRados::Bucket::UpdateIndex::prepare(RGWModifyOp op, const string *write_t
 int RGWRados::Bucket::UpdateIndex::complete(int64_t poolid, uint64_t epoch,
                                             uint64_t size, uint64_t accounted_size,
                                             ceph::real_time& ut, const string& etag,
-                                            const string& content_type,
+                                            const string& content_type, const string& storage_class,
                                             bufferlist *acl_bl,
                                             RGWObjCategory category,
                                             list<rgw_obj_index_key> *remove_objs, const string *user_data)
@@ -6435,6 +6444,7 @@ int RGWRados::Bucket::UpdateIndex::complete(int64_t poolid, uint64_t epoch,
   ent.meta.accounted_size = accounted_size;
   ent.meta.mtime = ut;
   ent.meta.etag = etag;
+  ent.meta.storage_class = storage_class;
   if (user_data)
     ent.meta.user_data = *user_data;
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3622,6 +3622,10 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
     op.setxattr(RGW_ATTR_MANIFEST, bl);
   }
 
+  if (meta.storage_class) {
+    storage_class = *meta.storage_class;
+  }
+
   for (iter = attrs.begin(); iter != attrs.end(); ++iter) {
     const string& name = iter->first;
     bufferlist& bl = iter->second;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6235,7 +6235,10 @@ int RGWRados::Object::Read::prepare()
   state.obj = astate->obj;
   store->obj_to_raw(bucket_info.placement_rule, state.obj, &state.head_obj);
 
-  r = store->get_obj_head_ioctx(bucket_info, state.obj, &state.io_ctx);
+  state.cur_pool = state.head_obj.pool;
+  state.cur_ioctx = &state.io_ctxs[state.cur_pool];
+
+  r = store->get_obj_head_ioctx(bucket_info, state.obj, state.cur_ioctx);
   if (r < 0) {
     return r;
   }
@@ -6558,8 +6561,6 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
     len = max_chunk_size;
 
 
-  state.io_ctx.locator_set_key(read_obj.loc);
-
   read_len = len;
 
   if (reading_from_head) {
@@ -6591,7 +6592,24 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
   ldout(cct, 20) << "rados->read obj-ofs=" << ofs << " read_ofs=" << read_ofs << " read_len=" << read_len << dendl;
   op.read(read_ofs, read_len, pbl, NULL);
 
-  r = state.io_ctx.operate(read_obj.oid, &op, NULL);
+  if (state.cur_pool != read_obj.pool) {
+    auto iter = state.io_ctxs.find(read_obj.pool);
+    if (iter == state.io_ctxs.end()) {
+      state.cur_ioctx = &state.io_ctxs[read_obj.pool];
+      r = store->open_pool_ctx(read_obj.pool, *state.cur_ioctx);
+      if (r < 0) {
+        ldout(cct, 20) << "ERROR: failed to open pool context for pool=" << read_obj.pool << " r=" << r << dendl;
+        return r;
+      }
+    } else {
+      state.cur_ioctx = &iter->second;
+    }
+    state.cur_pool = read_obj.pool;
+  }
+
+  state.cur_ioctx->locator_set_key(read_obj.loc);
+
+  r = state.cur_ioctx->operate(read_obj.oid, &op, NULL);
   ldout(cct, 20) << "rados->read r=" << r << " bl.length=" << bl.length() << dendl;
 
   if (r < 0) {
@@ -6983,7 +7001,7 @@ int RGWRados::Object::Read::iterate(int64_t ofs, int64_t end, RGWGetDataCB *cb)
   RGWObjectCtx& obj_ctx = source->get_ctx();
 
   data->rados = store;
-  data->io_ctx.dup(state.io_ctx);
+  data->io_ctx.dup(*state.cur_ioctx);
   data->client_cb = cb;
 
   int r = store->iterate_obj(obj_ctx, source->get_bucket_info(), state.obj, ofs, end, cct->_conf->rgw_get_obj_max_req_size, _get_obj_iterate_cb, (void *)data);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -108,16 +108,18 @@ static RGWObjCategory main_category = RGW_OBJ_CATEGORY_MAIN;
 
 
 static bool rgw_get_obj_data_pool(const RGWZoneGroup& zonegroup, const RGWZoneParams& zone_params,
-                                  const string& placement_id, const rgw_obj& obj, rgw_pool *pool)
+                                  const rgw_placement_rule& head_placement_rule,
+                                  const rgw_obj& obj, rgw_pool *pool)
 {
-  if (!zone_params.get_head_data_pool(placement_id, obj, pool)) {
+  if (!zone_params.get_head_data_pool(head_placement_rule, obj, pool)) {
     RGWZonePlacementInfo placement;
-    if (!zone_params.get_placement(zonegroup.default_placement, &placement)) {
+    if (!zone_params.get_placement(zonegroup.default_placement.name, &placement)) {
       return false;
     }
 
     if (!obj.in_extra_data) {
-      *pool = placement.data_pool;
+#warning zonegroup default placement backward compatibility json decode/encode
+      *pool = placement.get_data_pool(zonegroup.default_placement.storage_class);
     } else {
       *pool = placement.get_data_extra_pool();
     }
@@ -127,11 +129,12 @@ static bool rgw_get_obj_data_pool(const RGWZoneGroup& zonegroup, const RGWZonePa
 }
 
 static bool rgw_obj_to_raw(const RGWZoneGroup& zonegroup, const RGWZoneParams& zone_params,
-                           const string& placement_id, const rgw_obj& obj, rgw_raw_obj *raw_obj)
+                           const rgw_placement_rule& head_placement_rule,
+                           const rgw_obj& obj, rgw_raw_obj *raw_obj)
 {
   get_obj_bucket_and_oid_loc(obj, raw_obj->oid, raw_obj->loc);
 
-  return rgw_get_obj_data_pool(zonegroup, zone_params, placement_id, obj, &raw_obj->pool);
+  return rgw_get_obj_data_pool(zonegroup, zone_params, head_placement_rule, obj, &raw_obj->pool);
 }
 
 rgw_raw_obj rgw_obj_select::get_raw_obj(const RGWZoneGroup& zonegroup, const RGWZoneParams& zone_params) const
@@ -221,11 +224,6 @@ void RGWObjManifest::obj_iterator::operator++()
   if (manifest->explicit_objs) {
     ++explicit_iter;
 
-    if (explicit_iter == manifest->objs.end()) {
-      ofs = manifest->obj_size;
-      return;
-    }
-
     update_explicit_pos();
 
     update_location();
@@ -308,8 +306,8 @@ void RGWObjManifest::obj_iterator::operator++()
 }
 
 int RGWObjManifest::generator::create_begin(CephContext *cct, RGWObjManifest *_m,
-                                            const string& head_placement_rule,
-                                            const string *tail_placement_rule,
+                                            const rgw_placement_rule& head_placement_rule,
+                                            const rgw_placement_rule *tail_placement_rule,
                                             const rgw_bucket& _b, const rgw_obj& _obj)
 {
   manifest = _m;
@@ -1028,7 +1026,7 @@ int RGWRados::get_max_chunk_size(const rgw_pool& pool, uint64_t *max_chunk_size)
   return 0;
 }
 
-int RGWRados::get_max_chunk_size(const string& placement_rule, const rgw_obj& obj, uint64_t *max_chunk_size)
+int RGWRados::get_max_chunk_size(const rgw_placement_rule& placement_rule, const rgw_obj& obj, uint64_t *max_chunk_size)
 {
   rgw_pool pool;
   if (!get_obj_data_pool(placement_rule, obj, &pool)) {
@@ -1745,11 +1743,11 @@ int RGWRados::open_bucket_index_ctx(const RGWBucketInfo& bucket_info, librados::
   auto& zonegroup = svc.zone->get_zonegroup();
   auto& zone_params = svc.zone->get_zone_params();
 
-  const string *rule = &bucket_info.placement_rule;
+  const rgw_placement_rule *rule = &bucket_info.placement_rule;
   if (rule->empty()) {
     rule = &zonegroup.default_placement;
   }
-  auto iter = zone_params.placement_pools.find(*rule);
+  auto iter = zone_params.placement_pools.find(rule->name);
   if (iter == zone_params.placement_pools.end()) {
     ldout(cct, 0) << "could not find placement rule " << *rule << " within zonegroup " << dendl;
     return -EINVAL;
@@ -2797,7 +2795,7 @@ void RGWRados::create_bucket_id(string *bucket_id)
 
 int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& zonegroup_id,
-                            const string& placement_rule,
+                            const rgw_placement_rule& placement_rule,
                             const string& swift_ver_location,
                             const RGWQuotaInfo * pquota_info,
 			    map<std::string, bufferlist>& attrs,
@@ -2810,13 +2808,13 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
 			    bool exclusive)
 {
 #define MAX_CREATE_RETRIES 20 /* need to bound retries */
-  string selected_placement_rule_name;
+  rgw_placement_rule selected_placement_rule;
   RGWZonePlacementInfo rule_info;
 
   for (int i = 0; i < MAX_CREATE_RETRIES; i++) {
     int ret = 0;
     ret = svc.zone->select_bucket_placement(owner, zonegroup_id, placement_rule,
-                                            &selected_placement_rule_name, &rule_info);
+                                            &selected_placement_rule, &rule_info);
     if (ret < 0)
       return ret;
 
@@ -2839,7 +2837,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.bucket = bucket;
     info.owner = owner.user_id;
     info.zonegroup = zonegroup_id;
-    info.placement_rule = selected_placement_rule_name;
+    info.placement_rule = selected_placement_rule;
     info.index_type = rule_info.index_type;
     info.swift_ver_location = swift_ver_location;
     info.swift_versioning = (!swift_ver_location.empty());
@@ -2914,7 +2912,7 @@ bool RGWRados::get_obj_data_pool(const string& placement_rule, const rgw_obj& ob
   return rgw_get_obj_data_pool(svc.zone->get_zonegroup(), svc.zone->get_zone_params(), placement_rule, obj, pool);
 }
 
-bool RGWRados::obj_to_raw(const string& placement_rule, const rgw_obj& obj, rgw_raw_obj *raw_obj)
+bool RGWRados::obj_to_raw(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_raw_obj *raw_obj)
 {
   get_obj_bucket_and_oid_loc(obj, raw_obj->oid, raw_obj->loc);
 
@@ -4290,7 +4288,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
   using namespace rgw::putobj;
   AioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
-  string *ptail_rule{nullptr};
+  rgw_placement_rule *ptail_rule{nullptr};
 #warning FIXME ptail_rule
   AtomicObjectProcessor processor(&aio, this, dest_bucket_info, ptail_rule, user_id,
                                   obj_ctx, dest_obj, olh_epoch, tag);
@@ -4328,8 +4326,9 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   boost::optional<RGWPutObj_Compress> compressor;
   CompressorRef plugin;
 
+#warning compression type
   const auto& compression_type = svc.zone->get_zone_params().get_compression_type(
-      dest_bucket_info.placement_rule);
+      dest_bucket_info.placement_rule.name);
   if (compression_type != "none") {
     plugin = Compressor::create(cct, compression_type);
     if (!plugin) {
@@ -4547,7 +4546,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
                rgw_obj& src_obj,
                RGWBucketInfo& dest_bucket_info,
                RGWBucketInfo& src_bucket_info,
-               const string *ptail_rule,
+               const rgw_placement_rule *ptail_rule,
                real_time *src_mtime,
                real_time *mtime,
                const real_time *mod_ptr,
@@ -4661,7 +4660,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   rgw_pool src_pool;
   rgw_pool dest_pool;
 
-  const string *src_rule{nullptr};
+  const rgw_placement_rule *src_rule{nullptr};
 
   if (astate->has_manifest) {
     src_rule = &astate->manifest.get_tail_placement().placement_rule;
@@ -4835,7 +4834,7 @@ done_ret:
 
 int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
                RGWBucketInfo& dest_bucket_info,
-               const string *ptail_rule,
+               const rgw_placement_rule *ptail_rule,
 	       RGWRados::Object::Read& read_op, off_t end,
                const rgw_obj& dest_obj,
 	       real_time *mtime,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3399,7 +3399,7 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
                obj,
                dest_bucket_info,
                bucket_info,
-               nullptr, /* const string *tail_rule */
+               bucket_info.placement_rule,
                NULL, /* time_t *src_mtime */
                NULL, /* time_t *mtime */
                NULL, /* const time_t *mod_ptr */
@@ -3486,7 +3486,7 @@ int RGWRados::swift_versioning_restore(RGWSysObjectCtx& sysobj_ctx,
                        archive_obj,   /* src obj */
                        bucket_info,   /* dest bucket info */
                        archive_binfo, /* src bucket info */
-                       nullptr,       /* const string *ptail_rule */
+                       bucket_info.placement_rule,  /* placement_rule */
                        nullptr,       /* time_t *src_mtime */
                        nullptr,       /* time_t *mtime */
                        nullptr,       /* const time_t *mod_ptr */
@@ -3647,6 +3647,12 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
     bufferlist bl;
     encode(store->svc.zone->get_zone_short_id(), bl);
     op.setxattr(RGW_ATTR_SOURCE_ZONE, bl);
+  }
+
+  if (!storage_class.empty()) {
+    bufferlist bl;
+    bl.append(storage_class);
+    op.setxattr(RGW_ATTR_STORAGE_CLASS, bl);
   }
 
   if (!op.size())
@@ -4045,7 +4051,8 @@ int RGWRados::rewrite_obj(RGWBucketInfo& dest_bucket_info, const rgw_obj& obj)
   attrset.erase(RGW_ATTR_ID_TAG);
   attrset.erase(RGW_ATTR_TAIL_TAG);
 
-  return copy_obj_data(rctx, dest_bucket_info, nullptr, read_op, obj_size - 1, obj, NULL, mtime, attrset,
+  return copy_obj_data(rctx, dest_bucket_info, dest_bucket_info.placement_rule,
+                       read_op, obj_size - 1, obj, NULL, mtime, attrset,
                        0, real_time(), NULL);
 }
 
@@ -4552,7 +4559,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
                rgw_obj& src_obj,
                RGWBucketInfo& dest_bucket_info,
                RGWBucketInfo& src_bucket_info,
-               rgw_placement_rule *ptail_rule,
+               const rgw_placement_rule& dest_placement,
                real_time *src_mtime,
                real_time *mtime,
                const real_time *mod_ptr,
@@ -4677,31 +4684,23 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     src_rule = &src_bucket_info.placement_rule;
   }
 
-  if (!ptail_rule) {
-    ptail_rule = &dest_bucket_info.placement_rule;
-  } else {
-    ptail_rule->inherit_from(dest_bucket_info.placement_rule);
-  }
-
-  auto& dest_storage_class = ptail_rule->get_storage_class();
-  bufferlist scbl;
-  scbl.append(dest_storage_class);
-  attrs[RGW_ATTR_STORAGE_CLASS] = scbl;
-
   if (!get_obj_data_pool(*src_rule, src_obj, &src_pool)) {
     ldout(cct, 0) << "ERROR: failed to locate data pool for " << src_obj << dendl;
     return -EIO;
   }
 
-  if (!get_obj_data_pool(*ptail_rule, dest_obj, &dest_pool)) {
+  if (!get_obj_data_pool(dest_placement, dest_obj, &dest_pool)) {
     ldout(cct, 0) << "ERROR: failed to locate data pool for " << dest_obj << dendl;
     return -EIO;
   }
 
   ldout(cct, 20) << __func__ << "(): src_rule=" << src_rule->to_str() << " src_pool=" << src_pool
-                             << " dest_rule=" << ptail_rule->to_str() << " dest_pool=" << dest_pool << dendl;
+                             << " dest_rule=" << dest_placement.to_str() << " dest_pool=" << dest_pool << dendl;
 
-  bool copy_data = !astate->has_manifest || (src_pool != dest_pool);
+  bool copy_data = !astate->has_manifest ||
+    (*src_rule != dest_placement) ||
+    (src_pool != dest_pool);
+
   bool copy_first = false;
   if (astate->has_manifest) {
     if (!astate->manifest.has_tail()) {
@@ -4733,7 +4732,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   }
 
   if (copy_data) { /* refcounting tail wouldn't work here, just copy the data */
-    return copy_obj_data(obj_ctx, dest_bucket_info, ptail_rule, read_op, obj_size - 1, dest_obj,
+    return copy_obj_data(obj_ctx, dest_bucket_info, dest_placement, read_op, obj_size - 1, dest_obj,
                          mtime, real_time(), attrs, olh_epoch, delete_at, petag);
   }
 
@@ -4850,7 +4849,7 @@ done_ret:
 
 int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
                RGWBucketInfo& dest_bucket_info,
-               const rgw_placement_rule *ptail_rule,
+               const rgw_placement_rule& dest_placement,
 	       RGWRados::Object::Read& read_op, off_t end,
                const rgw_obj& dest_obj,
 	       real_time *mtime,
@@ -4865,7 +4864,7 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
 
   using namespace rgw::putobj;
   AioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
-  AtomicObjectProcessor processor(&aio, this, dest_bucket_info, ptail_rule,
+  AtomicObjectProcessor processor(&aio, this, dest_bucket_info, &dest_placement,
                                   dest_bucket_info.owner, obj_ctx,
                                   dest_obj, olh_epoch, tag);
   int ret = processor.prepare();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -313,10 +313,13 @@ int RGWObjManifest::generator::create_begin(CephContext *cct, RGWObjManifest *_m
   manifest = _m;
 
   if (!tail_placement_rule) {
-    tail_placement_rule = &head_placement_rule;
+    manifest->set_tail_placement(head_placement_rule, _b);
+  } else {
+    rgw_placement_rule new_tail_rule = *tail_placement_rule;
+    new_tail_rule.inherit_from(head_placement_rule);
+    manifest->set_tail_placement(new_tail_rule, _b);
   }
 
-  manifest->set_tail_placement(*tail_placement_rule, _b);
   manifest->set_head(head_placement_rule, _obj, 0);
   last_ofs = 0;
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1771,6 +1771,7 @@ public:
       int complete(int64_t poolid, uint64_t epoch, uint64_t size,
                    uint64_t accounted_size, ceph::real_time& ut,
                    const string& etag, const string& content_type,
+                   const string& storage_class,
                    bufferlist *acl_bl, RGWObjCategory category,
 		   list<rgw_obj_index_key> *remove_objs, const string *user_data = nullptr);
       int complete_del(int64_t poolid, uint64_t epoch,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -136,15 +136,16 @@ static inline bool rgw_raw_obj_to_obj(const rgw_bucket& bucket, const rgw_raw_ob
   return true;
 }
 
+
 struct rgw_bucket_placement {
-  string placement_rule;
+  rgw_placement_rule placement_rule;
   rgw_bucket bucket;
 
   void dump(Formatter *f) const;
 };
 
 class rgw_obj_select {
-  string placement_rule;
+  rgw_placement_rule placement_rule;
   rgw_obj obj;
   rgw_raw_obj raw_obj;
   bool is_raw;
@@ -178,7 +179,7 @@ public:
     return *this;
   }
 
-  void set_placement_rule(const string& rule) {
+  void set_placement_rule(const rgw_placement_rule& rule) {
     placement_rule = rule;
   }
   void dump(Formatter *f) const;
@@ -403,7 +404,7 @@ protected:
 
   rgw_obj obj;
   uint64_t head_size;
-  string head_placement_rule;
+  rgw_placement_rule head_placement_rule;
 
   uint64_t max_head_size;
   string prefix;
@@ -603,7 +604,7 @@ public:
     return (obj_size > head_size);
   }
 
-  void set_head(const string& placement_rule, const rgw_obj& _o, uint64_t _s) {
+  void set_head(const rgw_placement_rule& placement_rule, const rgw_obj& _o, uint64_t _s) {
     head_placement_rule = placement_rule;
     obj = _o;
     head_size = _s;
@@ -618,7 +619,7 @@ public:
     return obj;
   }
 
-  void set_tail_placement(const string& placement_rule, const rgw_bucket& _b) {
+  void set_tail_placement(const rgw_placement_rule& placement_rule, const rgw_bucket& _b) {
     tail_placement.placement_rule = placement_rule;
     tail_placement.bucket = _b;
   }
@@ -627,7 +628,7 @@ public:
     return tail_placement;
   }
 
-  const string& get_head_placement_rule() {
+  const rgw_placement_rule& get_head_placement_rule() {
     return head_placement_rule;
   }
 
@@ -807,8 +808,8 @@ public:
     generator() : manifest(NULL), last_ofs(0), cur_part_ofs(0), cur_part_id(0), 
 		  cur_stripe(0), cur_stripe_size(0) {}
     int create_begin(CephContext *cct, RGWObjManifest *manifest,
-                     const string& head_placement_rule,
-                     const string *tail_placement_rule,
+                     const rgw_placement_rule& head_placement_rule,
+                     const rgw_placement_rule *tail_placement_rule,
                      const rgw_bucket& bucket,
                      const rgw_obj& obj);
 
@@ -1391,7 +1392,7 @@ public:
 
   int get_required_alignment(const rgw_pool& pool, uint64_t *alignment);
   int get_max_chunk_size(const rgw_pool& pool, uint64_t *max_chunk_size);
-  int get_max_chunk_size(const string& placement_rule, const rgw_obj& obj, uint64_t *max_chunk_size);
+  int get_max_chunk_size(const rgw_placement_rule& placement_rule, const rgw_obj& obj, uint64_t *max_chunk_size);
 
   uint32_t get_max_bucket_shards() {
     return rgw_shards_max();
@@ -1456,12 +1457,12 @@ public:
   int init_bucket_index(RGWBucketInfo& bucket_info, int num_shards);
   void create_bucket_id(string *bucket_id);
 
-  bool get_obj_data_pool(const string& placement_rule, const rgw_obj& obj, rgw_pool *pool);
-  bool obj_to_raw(const string& placement_rule, const rgw_obj& obj, rgw_raw_obj *raw_obj);
+  bool get_obj_data_pool(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_pool *pool);
+  bool obj_to_raw(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_raw_obj *raw_obj);
 
   int create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& zonegroup_id,
-                            const string& placement_rule,
+                            const rgw_placement_rule& placement_rule,
                             const string& swift_ver_location,
                             const RGWQuotaInfo * pquota_info,
                             map<std::string,bufferlist>& attrs,
@@ -1944,7 +1945,7 @@ public:
                rgw_obj& src_obj,
                RGWBucketInfo& dest_bucket_info,
                RGWBucketInfo& src_bucket_info,
-               const string *ptail_rule,
+               const rgw_placement_rule *ptail_rule,
                ceph::real_time *src_mtime,
                ceph::real_time *mtime,
                const ceph::real_time *mod_ptr,
@@ -1966,7 +1967,7 @@ public:
 
   int copy_obj_data(RGWObjectCtx& obj_ctx,
                RGWBucketInfo& dest_bucket_info,
-               const string *ptail_rule,
+               const rgw_placement_rule *ptail_rule,
 	       RGWRados::Object::Read& read_op, off_t end,
                const rgw_obj& dest_obj,
 	       ceph::real_time *mtime,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1609,6 +1609,7 @@ public:
         rgw_zone_set *zones_trace;
         bool modify_tail;
         bool completeMultipart;
+        std::optional<std::string> storage_class;
 
         MetaParams() : mtime(NULL), rmattrs(NULL), data(NULL), manifest(NULL), ptag(NULL),
                  remove_objs(NULL), category(RGW_OBJ_CATEGORY_MAIN), flags(0),

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1250,7 +1250,7 @@ class RGWRados : public AdminSocketHook
   uint32_t bucket_index_max_shards;
 
   int get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx);
-  int get_obj_head_ref(const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_rados_ref *ref);
+  int get_obj_head_ref(const rgw_placement_rule& rule, const rgw_obj& obj, rgw_rados_ref *ref);
   int get_system_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref);
   uint64_t max_bucket_id;
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1947,7 +1947,7 @@ public:
                rgw_obj& src_obj,
                RGWBucketInfo& dest_bucket_info,
                RGWBucketInfo& src_bucket_info,
-               const rgw_placement_rule *ptail_rule,
+               rgw_placement_rule *ptail_rule,
                ceph::real_time *src_mtime,
                ceph::real_time *mtime,
                const ceph::real_time *mod_ptr,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1104,7 +1104,7 @@ public:
     assert (!obj.empty());
     objs_state[obj].is_atomic = true;
   }
-  void set_prefetch_data(rgw_obj& obj) {
+  void set_prefetch_data(const rgw_obj& obj) {
     RWLock::WLocker wl(lock);
     assert (!obj.empty());
     objs_state[obj].prefetch_data = true;
@@ -2109,7 +2109,7 @@ public:
     RGWObjectCtx *rctx = static_cast<RGWObjectCtx *>(ctx);
     rctx->set_atomic(obj);
   }
-  void set_prefetch_data(void *ctx, rgw_obj& obj) {
+  void set_prefetch_data(void *ctx, const rgw_obj& obj) {
     RGWObjectCtx *rctx = static_cast<RGWObjectCtx *>(ctx);
     rctx->set_prefetch_data(obj);
   }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1948,7 +1948,7 @@ public:
                rgw_obj& src_obj,
                RGWBucketInfo& dest_bucket_info,
                RGWBucketInfo& src_bucket_info,
-               rgw_placement_rule *ptail_rule,
+               const rgw_placement_rule& dest_placement,
                ceph::real_time *src_mtime,
                ceph::real_time *mtime,
                const ceph::real_time *mod_ptr,
@@ -1970,7 +1970,7 @@ public:
 
   int copy_obj_data(RGWObjectCtx& obj_ctx,
                RGWBucketInfo& dest_bucket_info,
-               const rgw_placement_rule *ptail_rule,
+               const rgw_placement_rule& dest_placement,
 	       RGWRados::Object::Read& read_op, off_t end,
                const rgw_obj& dest_obj,
 	       ceph::real_time *mtime,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -806,7 +806,11 @@ public:
   public:
     generator() : manifest(NULL), last_ofs(0), cur_part_ofs(0), cur_part_id(0), 
 		  cur_stripe(0), cur_stripe_size(0) {}
-    int create_begin(CephContext *cct, RGWObjManifest *manifest, const string& placement_rule, const rgw_bucket& bucket, const rgw_obj& obj);
+    int create_begin(CephContext *cct, RGWObjManifest *manifest,
+                     const string& head_placement_rule,
+                     const string *tail_placement_rule,
+                     const rgw_bucket& bucket,
+                     const rgw_obj& obj);
 
     int create_next(uint64_t ofs);
 
@@ -1940,6 +1944,7 @@ public:
                rgw_obj& src_obj,
                RGWBucketInfo& dest_bucket_info,
                RGWBucketInfo& src_bucket_info,
+               const string *ptail_rule,
                ceph::real_time *src_mtime,
                ceph::real_time *mtime,
                const ceph::real_time *mod_ptr,
@@ -1961,6 +1966,7 @@ public:
 
   int copy_obj_data(RGWObjectCtx& obj_ctx,
                RGWBucketInfo& dest_bucket_info,
+               const string *ptail_rule,
 	       RGWRados::Object::Read& read_op, off_t end,
                const rgw_obj& dest_obj,
 	       ceph::real_time *mtime,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1548,7 +1548,9 @@ public:
       RGWRados::Object *source;
 
       struct GetObjState {
-        librados::IoCtx io_ctx;
+        map<rgw_pool, librados::IoCtx> io_ctxs;
+        rgw_pool cur_pool;
+        librados::IoCtx *cur_ioctx{nullptr};
         rgw_obj obj;
         rgw_raw_obj head_obj;
       } state;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -92,6 +92,7 @@ static const struct rgw_http_attr base_rgw_to_http_attrs[] = {
   { RGW_ATTR_CONTENT_ENC,       "Content-Encoding" },
   { RGW_ATTR_USER_MANIFEST,     "X-Object-Manifest" },
   { RGW_ATTR_X_ROBOTS_TAG ,     "X-Robots-Tag" },
+  { RGW_ATTR_STORAGE_CLASS ,    "X-Amz-Storage-Class" },
   /* RGW_ATTR_AMZ_WEBSITE_REDIRECT_LOCATION header depends on access mode:
    * S3 endpoint: x-amz-website-redirect-location
    * S3Website endpoint: Location
@@ -116,6 +117,7 @@ static const struct generic_attr generic_attrs[] = {
   { "HTTP_CONTENT_DISPOSITION", RGW_ATTR_CONTENT_DISP },
   { "HTTP_CONTENT_ENCODING",    RGW_ATTR_CONTENT_ENC },
   { "HTTP_X_ROBOTS_TAG",        RGW_ATTR_X_ROBOTS_TAG },
+  { "HTTP_X_AMZ_STORAGE_CLASS", RGW_ATTR_STORAGE_CLASS },
 };
 
 map<string, string> rgw_to_http_attrs;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -117,7 +117,6 @@ static const struct generic_attr generic_attrs[] = {
   { "HTTP_CONTENT_DISPOSITION", RGW_ATTR_CONTENT_DISP },
   { "HTTP_CONTENT_ENCODING",    RGW_ATTR_CONTENT_ENC },
   { "HTTP_X_ROBOTS_TAG",        RGW_ATTR_X_ROBOTS_TAG },
-  { "HTTP_X_AMZ_STORAGE_CLASS", RGW_ATTR_STORAGE_CLASS },
 };
 
 map<string, string> rgw_to_http_attrs;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -754,7 +754,8 @@ void RGWListBucket_ObjStore_S3::send_versioned_response()
       if (!iter->is_delete_marker()) {
 	s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
 	s->formatter->dump_int("Size", iter->meta.accounted_size);
-	s->formatter->dump_string("StorageClass", "STANDARD");
+	auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
+	s->formatter->dump_string("StorageClass", storage_class.c_str());
       }
       dump_owner(s, iter->meta.owner, iter->meta.owner_display_name);
       s->formatter->close_section();
@@ -831,7 +832,8 @@ void RGWListBucket_ObjStore_S3::send_response()
       dump_time(s, "LastModified", &iter->meta.mtime);
       s->formatter->dump_format("ETag", "\"%s\"", iter->meta.etag.c_str());
       s->formatter->dump_int("Size", iter->meta.accounted_size);
-      s->formatter->dump_string("StorageClass", "STANDARD");
+      auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->meta.storage_class);
+      s->formatter->dump_string("StorageClass", storage_class.c_str());
       dump_owner(s, iter->meta.owner, iter->meta.owner_display_name);
       if (s->system_request) {
         s->formatter->dump_string("RgwxTag", iter->tag);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1241,7 +1241,7 @@ int RGWCreateBucket_ObjStore_S3::get_params()
 
   size_t pos = location_constraint.find(':');
   if (pos != string::npos) {
-    placement_rule = location_constraint.substr(pos + 1);
+    placement_rule.init(location_constraint.substr(pos + 1), s->info.storage_class);
     location_constraint = location_constraint.substr(0, pos);
   }
 
@@ -3417,6 +3417,11 @@ int RGWHandler_REST_S3::init(RGWRados *store, struct req_state *s,
       ldout(s->cct, 0) << "failed to parse copy location" << dendl;
       return -EINVAL; // XXX why not -ERR_INVALID_BUCKET_NAME or -ERR_BAD_URL?
     }
+  }
+
+  const char *sc = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS");
+  if (sc) {
+    s->info.storage_class = sc;
   }
 
   return RGWHandler_REST::init(store, s, cio);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2683,7 +2683,8 @@ void RGWListMultipart_ObjStore_S3::send_response()
     s->formatter->dump_string("Bucket", s->bucket_name);
     s->formatter->dump_string("Key", s->object.name);
     s->formatter->dump_string("UploadId", upload_id);
-    s->formatter->dump_string("StorageClass", "STANDARD");
+    auto& storage_class = rgw_placement_rule::get_canonical_storage_class(upload_info.dest_placement.storage_class);
+    s->formatter->dump_string("StorageClass", storage_class.c_str());
     s->formatter->dump_int("PartNumberMarker", marker);
     s->formatter->dump_int("NextPartNumberMarker", cur_max);
     s->formatter->dump_int("MaxParts", max_parts);
@@ -2754,7 +2755,8 @@ void RGWListBucketMultiparts_ObjStore_S3::send_response()
       s->formatter->dump_string("UploadId", mp.get_upload_id());
       dump_owner(s, s->user->user_id, s->user->display_name, "Initiator");
       dump_owner(s, s->user->user_id, s->user->display_name);
-      s->formatter->dump_string("StorageClass", "STANDARD");
+      auto& storage_class = rgw_placement_rule::get_canonical_storage_class(iter->obj.meta.storage_class);
+      s->formatter->dump_string("StorageClass", storage_class.c_str());
       dump_time(s, "Initiated", &iter->obj.meta.mtime);
       s->formatter->close_section();
     }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1660,6 +1660,13 @@ int RGWPostObj_ObjStore_S3::get_params()
     env.add_var(part.name, part_str);
   } while (!done);
 
+  part_str(parts, "x-amz-storage-class", &s->dest_placement.storage_class);
+  if (!store->svc.zone->get_zone_params().valid_placement(s->dest_placement)) {
+    ldout(s->cct, 0) << "NOTICE: invalid dest placement: " << s->dest_placement.to_str() << dendl;
+    err_msg = "The storage class you specified is not valid";
+    return -EINVAL;
+  }
+
   string object_str;
   if (!part_str(parts, "key", &object_str)) {
     err_msg = "Key not specified";

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2177,6 +2177,7 @@ int RGWCopyObj_ObjStore_S3::get_params()
       (dest_bucket_name.compare(src_bucket_name) == 0) &&
       (dest_object.compare(src_object.name) == 0) &&
       src_object.instance.empty() &&
+      s->info.storage_class.storage_class.empty() &&
       (attrs_mod != RGWRados::ATTRSMOD_REPLACE)) {
     /* can only copy object into itself if replacing attrs */
     s->err.message = "This copy request is illegal because it is trying to copy "

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1241,7 +1241,7 @@ int RGWCreateBucket_ObjStore_S3::get_params()
 
   size_t pos = location_constraint.find(':');
   if (pos != string::npos) {
-    placement_rule.init(location_constraint.substr(pos + 1), s->info.storage_class);
+    placement_rule.init(location_constraint.substr(pos + 1), s->info.storage_class.storage_class);
     location_constraint = location_constraint.substr(0, pos);
   }
 
@@ -3421,7 +3421,7 @@ int RGWHandler_REST_S3::init(RGWRados *store, struct req_state *s,
 
   const char *sc = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS");
   if (sc) {
-    s->info.storage_class = sc;
+    s->info.storage_class.storage_class = sc;
   }
 
   return RGWHandler_REST::init(store, s, cio);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2321,7 +2321,7 @@ void RGWGetLC_ObjStore_S3::send_response()
   if (op_ret < 0)
     return;
 
-  config.dump_xml(s->formatter);
+  encode_xml("LifecycleConfiguration", XMLNS_AWS_S3, config, s->formatter);
   rgw_flush_formatter_and_reset(s, s->formatter);
 }
 
@@ -2514,7 +2514,7 @@ public:
     if (!field)
       return 0;
 
-    string& s = field->get_data();
+    auto& s = field->get_data();
 
     if (stringcasecmp(s, "Requester") == 0) {
       *requester_pays = true;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -402,7 +402,7 @@ void RGWGetObjTags_ObjStore_S3::send_response_data(bufferlist& bl)
 
 int RGWPutObjTags_ObjStore_S3::get_params()
 {
-  RGWObjTagsXMLParser parser;
+  RGWXMLParser parser;
 
   if (!parser.init()){
     return -EINVAL;
@@ -421,17 +421,17 @@ int RGWPutObjTags_ObjStore_S3::get_params()
     return -ERR_MALFORMED_XML;
   }
 
-  RGWObjTagSet_S3 *obj_tags_s3;
-  RGWObjTagging_S3 *tagging;
+  RGWObjTagging_S3 tagging;
 
-  tagging = static_cast<RGWObjTagging_S3 *>(parser.find_first("Tagging"));
-  obj_tags_s3 = static_cast<RGWObjTagSet_S3 *>(tagging->find_first("TagSet"));
-  if(!obj_tags_s3){
+  try {
+    RGWXMLDecoder::decode_xml("Tagging", tagging, &parser);
+  } catch (RGWXMLDecoder::err& err) {
+    ldout(s->cct, 5) << "Malformed tagging request: " << err << dendl;
     return -ERR_MALFORMED_XML;
   }
 
   RGWObjTags obj_tags;
-  r = obj_tags_s3->rebuild(obj_tags);
+  r = tagging.rebuild(obj_tags);
   if (r < 0)
     return r;
 
@@ -1741,7 +1741,7 @@ int RGWPostObj_ObjStore_S3::get_tags()
 {
   string tags_str;
   if (part_str(parts, "tagging", &tags_str)) {
-    RGWObjTagsXMLParser parser;
+    RGWXMLParser parser;
     if (!parser.init()){
       ldout(s->cct, 0) << "Couldn't init RGWObjTags XML parser" << dendl;
       err_msg = "Server couldn't process the request";
@@ -1753,17 +1753,17 @@ int RGWPostObj_ObjStore_S3::get_tags()
       return -EINVAL;
     }
 
-    RGWObjTagSet_S3 *obj_tags_s3;
-    RGWObjTagging_S3 *tagging;
+    RGWObjTagging_S3 tagging;
 
-    tagging = static_cast<RGWObjTagging_S3 *>(parser.find_first("Tagging"));
-    obj_tags_s3 = static_cast<RGWObjTagSet_S3 *>(tagging->find_first("TagSet"));
-    if(!obj_tags_s3){
-      return -ERR_MALFORMED_XML;
+    try {
+      RGWXMLDecoder::decode_xml("Tagging", tagging, &parser);
+    } catch (RGWXMLDecoder::err& err) {
+      ldout(s->cct, 5) << "Malformed tagging request: " << err << dendl;
+      return -EINVAL;
     }
 
     RGWObjTags obj_tags;
-    int r = obj_tags_s3->rebuild(obj_tags);
+    int r = tagging.rebuild(obj_tags);
     if (r < 0)
       return r;
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1243,8 +1243,10 @@ int RGWCreateBucket_ObjStore_S3::get_params()
 
   size_t pos = location_constraint.find(':');
   if (pos != string::npos) {
-    placement_rule.init(location_constraint.substr(pos + 1), s->info.storage_class.storage_class);
+    placement_rule.init(location_constraint.substr(pos + 1), s->info.storage_class);
     location_constraint = location_constraint.substr(0, pos);
+  } else {
+    placement_rule.storage_class = s->info.storage_class;
   }
 
   return 0;
@@ -2179,7 +2181,7 @@ int RGWCopyObj_ObjStore_S3::get_params()
       (dest_bucket_name.compare(src_bucket_name) == 0) &&
       (dest_object.compare(src_object.name) == 0) &&
       src_object.instance.empty() &&
-      s->info.storage_class.storage_class.empty() &&
+      s->info.storage_class.empty() &&
       (attrs_mod != RGWRados::ATTRSMOD_REPLACE)) {
     /* can only copy object into itself if replacing attrs */
     s->err.message = "This copy request is illegal because it is trying to copy "
@@ -3424,7 +3426,7 @@ int RGWHandler_REST_S3::init(RGWRados *store, struct req_state *s,
 
   const char *sc = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS");
   if (sc) {
-    s->info.storage_class.storage_class = sc;
+    s->info.storage_class = sc;
   }
 
   return RGWHandler_REST::init(store, s, cio);

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -298,7 +298,7 @@ public:
 
 class RGWGetLC_ObjStore_S3 : public RGWGetLC_ObjStore {
 protected:
-  RGWLifecycleConfiguration_S3  config;
+  RGWLifecycleConfiguration_S3 config;
 public:
   RGWGetLC_ObjStore_S3() {}
   ~RGWGetLC_ObjStore_S3() override {}

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -711,7 +711,7 @@ int RGWCreateBucket_ObjStore_SWIFT::get_params()
   location_constraint = store->svc.zone->get_zonegroup().api_name;
   get_rmattrs_from_headers(s, CONT_PUT_ATTR_PREFIX,
                            CONT_REMOVE_ATTR_PREFIX, rmattr_names);
-  placement_rule.init(s->info.env->get("HTTP_X_STORAGE_POLICY", ""), s->info.storage_class.storage_class);
+  placement_rule.init(s->info.env->get("HTTP_X_STORAGE_POLICY", ""), s->info.storage_class);
 
   return get_swift_versioning_settings(s, swift_ver_location);
 }
@@ -1125,7 +1125,7 @@ int RGWPutMetadataBucket_ObjStore_SWIFT::get_params()
 
   get_rmattrs_from_headers(s, CONT_PUT_ATTR_PREFIX, CONT_REMOVE_ATTR_PREFIX,
 			   rmattr_names);
-  placement_rule.init(s->info.env->get("HTTP_X_STORAGE_POLICY", ""), s->info.storage_class.storage_class);
+  placement_rule.init(s->info.env->get("HTTP_X_STORAGE_POLICY", ""), s->info.storage_class);
 
   return get_swift_versioning_settings(s, swift_ver_location);
 }
@@ -3050,7 +3050,7 @@ int RGWHandler_REST_SWIFT::init(RGWRados* store, struct req_state* s,
     s->op = OP_PUT;
   }
 
-  s->info.storage_class.storage_class = s->info.env->get("HTTP_X_OBJECT_STORAGE_CLASS", "");
+  s->info.storage_class = s->info.env->get("HTTP_X_OBJECT_STORAGE_CLASS", "");
 
   return RGWHandler_REST::init(store, s, cio);
 }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -711,7 +711,7 @@ int RGWCreateBucket_ObjStore_SWIFT::get_params()
   location_constraint = store->svc.zone->get_zonegroup().api_name;
   get_rmattrs_from_headers(s, CONT_PUT_ATTR_PREFIX,
                            CONT_REMOVE_ATTR_PREFIX, rmattr_names);
-  placement_rule.init(s->info.env->get("HTTP_X_STORAGE_POLICY", ""), s->info.storage_class);
+  placement_rule.init(s->info.env->get("HTTP_X_STORAGE_POLICY", ""), s->info.storage_class.storage_class);
 
   return get_swift_versioning_settings(s, swift_ver_location);
 }
@@ -1125,7 +1125,7 @@ int RGWPutMetadataBucket_ObjStore_SWIFT::get_params()
 
   get_rmattrs_from_headers(s, CONT_PUT_ATTR_PREFIX, CONT_REMOVE_ATTR_PREFIX,
 			   rmattr_names);
-  placement_rule.init(s->info.env->get("HTTP_X_STORAGE_POLICY", ""), s->info.storage_class);
+  placement_rule.init(s->info.env->get("HTTP_X_STORAGE_POLICY", ""), s->info.storage_class.storage_class);
 
   return get_swift_versioning_settings(s, swift_ver_location);
 }
@@ -3050,7 +3050,7 @@ int RGWHandler_REST_SWIFT::init(RGWRados* store, struct req_state* s,
     s->op = OP_PUT;
   }
 
-  s->info.storage_class = s->info.env->get("HTTP_X_OBJECT_STORAGE_CLASS", "");
+  s->info.storage_class.storage_class = s->info.env->get("HTTP_X_OBJECT_STORAGE_CLASS", "");
 
   return RGWHandler_REST::init(store, s, cio);
 }

--- a/src/rgw/rgw_tag_s3.cc
+++ b/src/rgw/rgw_tag_s3.cc
@@ -6,43 +6,41 @@
 
 #include "rgw_tag_s3.h"
 
-bool RGWObjTagEntry_S3::xml_end(const char*){
-  RGWObjTagKey_S3 *key_obj = static_cast<RGWObjTagKey_S3 *>(find_first("Key"));
-  RGWObjTagValue_S3 *val_obj = static_cast<RGWObjTagValue_S3 *>(find_first("Value"));
-
-  if (!key_obj)
-    return false;
-
-  string s = key_obj->get_data();
-  if (s.empty()){
-    return false;
-  }
-
-  key = s;
-  if (val_obj) {
-    val = val_obj->get_data();
-  }
-
-  return true;
+void RGWObjTagEntry_S3::decode_xml(XMLObj *obj) {
+  RGWXMLDecoder::decode_xml("Key", key, obj, true);
+  RGWXMLDecoder::decode_xml("Value", val, obj, true);
 }
 
-bool RGWObjTagSet_S3::xml_end(const char*){
-  XMLObjIter iter = find("Tag");
-  RGWObjTagEntry_S3 *tagentry = static_cast<RGWObjTagEntry_S3 *>(iter.get_next());
-  while (tagentry) {
-    const std::string& key = tagentry->get_key();
-    const std::string& val = tagentry->get_val();
-    if (!add_tag(key,val))
-      return false;
+void RGWObjTagEntry_S3::dump_xml(Formatter *f) const {
+  encode_xml("Key", key, f);
+  encode_xml("Value", val, f);
 
-    tagentry = static_cast<RGWObjTagEntry_S3 *>(iter.get_next());
+  if (key.empty()) {
+    throw RGWXMLDecoder::err("empty key");
   }
-  return true;
+
+  if (val.empty()) {
+    throw RGWXMLDecoder::err("empty val");
+  }
 }
 
-int RGWObjTagSet_S3::rebuild(RGWObjTags& dest){
+void RGWObjTagSet_S3::decode_xml(XMLObj *obj) {
+  vector<RGWObjTagEntry_S3> entries;
+
+  RGWXMLDecoder::decode_xml("Tag", entries, obj, true);
+
+  for (auto& entry : entries) {
+    const std::string& key = entry.get_key();
+    const std::string& val = entry.get_val();
+    if (!add_tag(key,val)) {
+      throw RGWXMLDecoder::err("failed to add tag");
+    }
+  }
+}
+
+int RGWObjTagSet_S3::rebuild(RGWObjTags& dest) {
   int ret;
-  for (const auto &it: tag_map){
+  for (const auto &it : tag_map){
     ret = dest.check_and_add_tag(it.first, it.second);
     if (ret < 0)
       return ret;
@@ -50,34 +48,15 @@ int RGWObjTagSet_S3::rebuild(RGWObjTags& dest){
   return 0;
 }
 
-bool RGWObjTagging_S3::xml_end(const char*){
-  RGWObjTagSet_S3 *tagset = static_cast<RGWObjTagSet_S3 *> (find_first("TagSet"));
-  return tagset != nullptr;
-
+void RGWObjTagging_S3::decode_xml(XMLObj *obj) {
+  RGWXMLDecoder::decode_xml("TagSet", tagset, obj, true);
 }
 
 void RGWObjTagSet_S3::dump_xml(Formatter *f) const {
-  for (const auto& tag: tag_map){
-    f->open_object_section("Tag");
-    f->dump_string("Key", tag.first);
-    f->dump_string("Value", tag.second);
-    f->close_section();
+  for (const auto& tag : tag_map){
+    Formatter::ObjectSection os(*f, "Tag");
+    encode_xml("Key", tag.first, f);
+    encode_xml("Value", tag.second, f);
   }
 }
 
-XMLObj *RGWObjTagsXMLParser::alloc_obj(const char *el){
-  XMLObj* obj = nullptr;
-  if(strcmp(el,"Tagging") == 0) {
-    obj = new RGWObjTagging_S3();
-  } else if (strcmp(el,"TagSet") == 0) {
-    obj = new RGWObjTagSet_S3();
-  } else if (strcmp(el,"Tag") == 0) {
-    obj = new RGWObjTagEntry_S3();
-  } else if (strcmp(el,"Key") == 0) {
-    obj = new RGWObjTagKey_S3();
-  } else if (strcmp(el,"Value") == 0) {
-    obj = new RGWObjTagValue_S3();
-  }
-
-  return obj;
-}

--- a/src/rgw/rgw_tag_s3.h
+++ b/src/rgw/rgw_tag_s3.h
@@ -14,15 +14,7 @@
 #include "rgw_tag.h"
 #include "rgw_xml.h"
 
-struct RGWObjTagKey_S3: public XMLObj
-{
-};
-
-struct RGWObjTagValue_S3: public XMLObj
-{
-};
-
-class RGWObjTagEntry_S3: public XMLObj
+class RGWObjTagEntry_S3
 {
   std::string key;
   std::string val;
@@ -31,32 +23,31 @@ public:
   RGWObjTagEntry_S3(const std::string &k, const std::string &v):key(k),val(v) {};
   ~RGWObjTagEntry_S3() {}
 
-  bool xml_end(const char*) override;
-  const std::string& get_key () const { return key;}
-  const std::string& get_val () const { return val;}
-  //void to_xml(CephContext *cct, ostream& out) const;
-};
+  const std::string& get_key () const { return key; }
+  const std::string& get_val () const { return val; }
 
-class RGWObjTagSet_S3: public RGWObjTags, public XMLObj
-{
-public:
-  bool xml_end(const char*) override;
   void dump_xml(Formatter *f) const;
+  void decode_xml(XMLObj *obj);
+};
+
+class RGWObjTagSet_S3: public RGWObjTags
+{
+public:
   int rebuild(RGWObjTags& dest);
+
+  void dump_xml(Formatter *f) const;
+  void decode_xml(XMLObj *obj);
 };
 
-class RGWObjTagging_S3: public XMLObj
+class RGWObjTagging_S3
 {
+  RGWObjTagSet_S3 tagset;
 public:
-  bool xml_end(const char*) override;
+  void decode_xml(XMLObj *obj);
+  int rebuild(RGWObjTags& dest) {
+    return tagset.rebuild(dest);
+  }
 };
 
-class RGWObjTagsXMLParser : public RGWXMLParser
-{
-  XMLObj *alloc_obj(const char *el) override;
-public:
-  RGWObjTagsXMLParser() {}
-  ~RGWObjTagsXMLParser() {}
-};
 
 #endif /* RGW_TAG_S3_H */

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -65,7 +65,7 @@ int seed::get_torrent_file(RGWRados::Object::Read &read_op,
 
   const set<string> obj_key{RGW_OBJ_TORRENT};
   map<string, bufferlist> m;
-  const int r = read_op.state.io_ctx.omap_get_vals_by_keys(oid, obj_key, &m);
+  const int r = read_op.state.cur_ioctx->omap_get_vals_by_keys(oid, obj_key, &m);
   if (r < 0) {
     ldout(s->cct, 0) << "ERROR: omap_get_vals_by_keys failed: " << r << dendl;
     return r;

--- a/src/rgw/rgw_xml.cc
+++ b/src/rgw/rgw_xml.cc
@@ -120,6 +120,20 @@ find(string name)
   return iter;
 }
 
+XMLObjIter XMLObj::find_first()
+{
+  XMLObjIter iter;
+  map<string, XMLObj *>::iterator first;
+  map<string, XMLObj *>::iterator last;
+  first = children.begin();
+  if (first != children.end()) {
+    last = children.upper_bound(first->first);
+  }else
+    last = children.end();
+  iter.set(first, last);
+  return iter;
+}
+
 XMLObj *XMLObj::
 find_first(string name)
 {

--- a/src/rgw/rgw_xml.cc
+++ b/src/rgw/rgw_xml.cc
@@ -44,6 +44,16 @@ get_next()
   return obj;
 }
 
+bool XMLObjIter::get_name(string *name) const
+{
+  if (cur == end) {
+    return false;
+  }
+
+  *name = cur->first;
+  return true;
+}
+
 ostream& operator<<(ostream &out, const XMLObj &obj) {
    out << obj.obj_type << ": " << obj.data;
    return out;
@@ -77,10 +87,16 @@ xml_handle_data(const char *s, int len)
   data.append(s, len);
 }
 
-string& XMLObj::
+const string& XMLObj::
 XMLObj::get_data()
 {
   return data;
+}
+
+const string& XMLObj::
+XMLObj::get_obj_type()
+{
+  return obj_type;
 }
 
 XMLObj *XMLObj::
@@ -126,10 +142,7 @@ XMLObjIter XMLObj::find_first()
   map<string, XMLObj *>::iterator first;
   map<string, XMLObj *>::iterator last;
   first = children.begin();
-  if (first != children.end()) {
-    last = children.upper_bound(first->first);
-  }else
-    last = children.end();
+  last = children.end();
   iter.set(first, last);
   return iter;
 }
@@ -259,7 +272,7 @@ bool RGWXMLParser::parse(const char *_buf, int len, int done)
 
 void decode_xml_obj(unsigned long& val, XMLObj *obj)
 {
-  string& s = obj->get_data();
+  auto& s = obj->get_data();
   const char *start = s.c_str();
   char *p;
 

--- a/src/rgw/rgw_xml.h
+++ b/src/rgw/rgw_xml.h
@@ -51,6 +51,7 @@ public:
   void add_child(string el, XMLObj *obj);
   bool get_attr(string name, string& attr);
   XMLObjIter find(string name);
+  XMLObjIter find_first();
   XMLObj *find_first(string name);
 
   friend ostream& operator<<(ostream &out, const XMLObj &obj);
@@ -117,6 +118,11 @@ public:
   static void decode_xml(const char *name, T& val, T& default_val, XMLObj *obj);
 };
 
+static inline ostream& operator<<(ostream &out, RGWXMLDecoder::err& err)
+{
+  return out << err.message;
+}
+
 template<class T>
 void decode_xml_obj(T& val, XMLObj *obj)
 {
@@ -155,17 +161,17 @@ void do_decode_xml_obj(list<T>& l, const string& name, XMLObj *obj)
 }
 
 template<class T>
-void do_decode_xml_obj(vector<T>& l, const string& name, XMLObj *obj)
+void decode_xml_obj(std::vector<T>& v, XMLObj *obj)
 {
-  l.clear();
+  v.clear();
 
-  XMLObjIter iter = obj->find(name);
+  XMLObjIter iter = obj->find_first();
   XMLObj *o;
 
-  while (o = iter.get_next()) {
+  while ((o = iter.get_next())) {
     T val;
     decode_xml_obj(val, o);
-    l.push_back(val);
+    v.push_back(val);
   }
 }
 

--- a/src/rgw/rgw_xml.h
+++ b/src/rgw/rgw_xml.h
@@ -21,6 +21,7 @@ public:
   ~XMLObjIter();
   void set(const XMLObjIter::map_iter_t &_cur, const XMLObjIter::map_iter_t &_end);
   XMLObj *get_next();
+  bool get_name(string *name) const;
 };
 
 /**
@@ -46,7 +47,8 @@ public:
   bool xml_start(XMLObj *parent, const char *el, const char **attr);
   virtual bool xml_end(const char *el);
   virtual void xml_handle_data(const char *s, int len);
-  string& get_data();
+  const string& get_data();
+  const string& get_obj_type();
   XMLObj *get_parent();
   void add_child(string el, XMLObj *obj);
   bool get_attr(string name, string& attr);
@@ -111,6 +113,9 @@ public:
   template<class T>
   static bool decode_xml(const char *name, T& val, XMLObj *obj, bool mandatory = false);
 
+  template<class T>
+  static bool decode_xml(const char *name, std::vector<T>& v, XMLObj *obj, bool mandatory = false);
+
   template<class C>
   static bool decode_xml(const char *name, C& container, void (*cb)(C&, XMLObj *obj), XMLObj *obj, bool mandatory = false);
 
@@ -161,21 +166,6 @@ void do_decode_xml_obj(list<T>& l, const string& name, XMLObj *obj)
 }
 
 template<class T>
-void decode_xml_obj(std::vector<T>& v, XMLObj *obj)
-{
-  v.clear();
-
-  XMLObjIter iter = obj->find_first();
-  XMLObj *o;
-
-  while ((o = iter.get_next())) {
-    T val;
-    decode_xml_obj(val, o);
-    v.push_back(val);
-  }
-}
-
-template<class T>
 bool RGWXMLDecoder::decode_xml(const char *name, T& val, XMLObj *obj, bool mandatory)
 {
   XMLObjIter iter = obj->find(name);
@@ -197,6 +187,36 @@ bool RGWXMLDecoder::decode_xml(const char *name, T& val, XMLObj *obj, bool manda
     throw err(s);
   }
 
+  return true;
+}
+
+template<class T>
+bool RGWXMLDecoder::decode_xml(const char *name, std::vector<T>& v, XMLObj *obj, bool mandatory)
+{
+  XMLObjIter iter = obj->find(name);
+  XMLObj *o = iter.get_next();
+
+  v.clear();
+
+  if (!o) {
+    if (mandatory) {
+      string s = "missing mandatory field " + string(name);
+      throw err(s);
+    }
+    return false;
+  }
+
+  do {
+    T val;
+    try {
+      decode_xml_obj(val, o);
+    } catch (err& e) {
+      string s = string(name) + ": ";
+      s.append(e.message);
+      throw err(s);
+    }
+    v.push_back(val);
+  } while ((o = iter.get_next()));
   return true;
 }
 
@@ -250,6 +270,14 @@ template<class T>
 static void encode_xml(const char *name, const T& val, ceph::Formatter *f)
 {
   f->open_object_section(name);
+  val.dump_xml(f);
+  f->close_section();
+}
+
+template<class T>
+static void encode_xml(const char *name, const char *ns, const T& val, ceph::Formatter *f)
+{
+  f->open_object_section_in_ns(name, ns);
   val.dump_xml(f);
   f->close_section();
 }

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -73,7 +73,7 @@ int RGWZoneGroup::create_default(bool old_format)
   RGWZoneGroupPlacementTarget placement_target;
   placement_target.name = "default-placement";
   placement_targets[placement_target.name] = placement_target;
-  default_placement = "default-placement";
+  default_placement.name = "default-placement";
 
   RGWZoneParams zone_params(default_zone_name);
 
@@ -287,7 +287,7 @@ void RGWZoneGroup::post_process_params()
   }
 
   if (default_placement.empty() && !placement_targets.empty()) {
-    default_placement = placement_targets.begin()->first;
+    default_placement.init(placement_targets.begin()->first, RGW_STORAGE_CLASS_STANDARD);
   }
 }
 
@@ -1536,7 +1536,9 @@ int get_zones_pool_set(CephContext* cct,
       pool_names.insert(zone.reshard_pool);
       for(auto& iter : zone.placement_pools) {
 	pool_names.insert(iter.second.index_pool);
-	pool_names.insert(iter.second.data_pool);
+        for (auto& pi : iter.second.data_pools) {
+          pool_names.insert(pi.second);
+        }
 	pool_names.insert(iter.second.data_extra_pool);
       }
     }
@@ -1610,8 +1612,10 @@ int RGWZoneParams::fix_pool_names()
   for(auto& iter : placement_pools) {
     iter.second.index_pool = fix_zone_pool_dup(pools, name, "." + default_bucket_index_pool_suffix,
                                                iter.second.index_pool);
-    iter.second.data_pool = fix_zone_pool_dup(pools, name, "." + default_storage_pool_suffix,
-                                              iter.second.data_pool);
+    for (auto& pi : iter.second.data_pools) {
+      pi.second = fix_zone_pool_dup(pools, name, "." + default_storage_pool_suffix,
+                                                pi.second);
+    }
     iter.second.data_extra_pool= fix_zone_pool_dup(pools, name, "." + default_storage_extra_pool_suffix,
                                                    iter.second.data_extra_pool);
   }
@@ -1631,7 +1635,7 @@ int RGWZoneParams::create(bool exclusive)
     /* a new system, let's set new placement info */
     RGWZonePlacementInfo default_placement;
     default_placement.index_pool = name + "." + default_bucket_index_pool_suffix;
-    default_placement.data_pool =  name + "." + default_storage_pool_suffix;
+    default_placement.data_pools[RGW_STORAGE_CLASS_STANDARD] =  name + "." + default_storage_pool_suffix;
     default_placement.data_extra_pool = name + "." + default_storage_extra_pool_suffix;
     placement_pools["default-placement"] = default_placement;
   }

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1536,8 +1536,10 @@ int get_zones_pool_set(CephContext* cct,
       pool_names.insert(zone.reshard_pool);
       for(auto& iter : zone.placement_pools) {
 	pool_names.insert(iter.second.index_pool);
-        for (auto& pi : iter.second.data_pools) {
-          pool_names.insert(pi.second);
+        for (auto& pi : iter.second.storage_classes.get_all()) {
+          if (pi.second.data_pool) {
+            pool_names.insert(pi.second.data_pool.get());
+          }
         }
 	pool_names.insert(iter.second.data_extra_pool);
       }
@@ -1612,9 +1614,12 @@ int RGWZoneParams::fix_pool_names()
   for(auto& iter : placement_pools) {
     iter.second.index_pool = fix_zone_pool_dup(pools, name, "." + default_bucket_index_pool_suffix,
                                                iter.second.index_pool);
-    for (auto& pi : iter.second.data_pools) {
-      pi.second = fix_zone_pool_dup(pools, name, "." + default_storage_pool_suffix,
-                                                pi.second);
+    for (auto& pi : iter.second.storage_classes.get_all()) {
+      if (pi.second.data_pool) {
+        rgw_pool& pool = pi.second.data_pool.get();
+        pool = fix_zone_pool_dup(pools, name, "." + default_storage_pool_suffix,
+                                 pool);
+      }
     }
     iter.second.data_extra_pool= fix_zone_pool_dup(pools, name, "." + default_storage_extra_pool_suffix,
                                                    iter.second.data_extra_pool);
@@ -1635,7 +1640,8 @@ int RGWZoneParams::create(bool exclusive)
     /* a new system, let's set new placement info */
     RGWZonePlacementInfo default_placement;
     default_placement.index_pool = name + "." + default_bucket_index_pool_suffix;
-    default_placement.data_pools[RGW_STORAGE_CLASS_STANDARD] =  name + "." + default_storage_pool_suffix;
+    rgw_pool pool = name + "." + default_storage_pool_suffix;
+    default_placement.storage_classes.set_storage_class(RGW_STORAGE_CLASS_STANDARD, &pool, nullptr);
     default_placement.data_extra_pool = name + "." + default_storage_extra_pool_suffix;
     placement_pools["default-placement"] = default_placement;
   }
@@ -1735,14 +1741,14 @@ int RGWZoneParams::set_as_default(bool exclusive)
   return RGWSystemMetaObj::set_as_default(exclusive);
 }
 
-const string& RGWZoneParams::get_compression_type(const string& placement_rule) const
+const string& RGWZoneParams::get_compression_type(const rgw_placement_rule& placement_rule) const
 {
   static const std::string NONE{"none"};
-  auto p = placement_pools.find(placement_rule);
+  auto p = placement_pools.find(placement_rule.name);
   if (p == placement_pools.end()) {
     return NONE;
   }
-  const auto& type = p->second.compression_type;
+  const auto& type = p->second.get_compression_type(placement_rule.storage_class);
   return !type.empty() ? type : NONE;
 }
 

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -176,10 +176,12 @@ class RGWZoneStorageClasses {
   map<string, RGWZoneStorageClass> m;
 
   /* in memory only */
-  RGWZoneStorageClass *standard_class{&m[RGW_STORAGE_CLASS_STANDARD]};
+  RGWZoneStorageClass *standard_class;
 
 public:
-  RGWZoneStorageClasses() {}
+  RGWZoneStorageClasses() {
+    standard_class = &m[RGW_STORAGE_CLASS_STANDARD];
+  }
   RGWZoneStorageClasses(const RGWZoneStorageClasses& rhs) {
     m = rhs.m;
     standard_class = &m[RGW_STORAGE_CLASS_STANDARD];
@@ -234,6 +236,7 @@ public:
   void decode(bufferlist::const_iterator& bl) {
     DECODE_START(1, bl);
     decode(m, bl);
+    standard_class = &m[RGW_STORAGE_CLASS_STANDARD];
     DECODE_FINISH(bl);
   }
 

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -206,6 +206,9 @@ public:
   }
 
   bool exists(const string& sc) const {
+    if (sc.empty()) {
+      return true;
+    }
     auto iter = m.find(sc);
     return (iter != m.end());
   }
@@ -517,6 +520,14 @@ struct RGWZoneParams : RGWSystemMetaObj {
       *pool = iter->second.get_data_extra_pool();
     }
     return true;
+  }
+
+  bool valid_placement(const rgw_placement_rule& rule) const {
+    auto iter = placement_pools.find(rule.name);
+    if (iter == placement_pools.end()) {
+      return false;
+    }
+    return iter->second.storage_class_exists(rule.storage_class);
   }
 };
 WRITE_CLASS_ENCODER(RGWZoneParams)

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -205,6 +205,11 @@ public:
     return true;
   }
 
+  bool exists(const string& sc) const {
+    auto iter = m.find(sc);
+    return (iter != m.end());
+  }
+
   const map<string, RGWZoneStorageClass>& get_all() const {
     return m;
   }
@@ -325,6 +330,10 @@ struct RGWZonePlacementInfo {
       return no_compression;
     }
     return storage_class->compression_type.get_value_or(no_compression);
+  }
+
+  bool storage_class_exists(const string& sc) const {
+    return storage_classes.exists(sc);
   }
 
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -150,15 +150,16 @@ WRITE_CLASS_ENCODER(RGWSystemMetaObj)
 
 struct RGWZonePlacementInfo {
   rgw_pool index_pool;
-  rgw_pool data_pool;
+  rgw_pool standard_data_pool;
   rgw_pool data_extra_pool; /* if not set we should use data_pool */
+  map<string, rgw_pool> data_pools;
   RGWBucketIndexType index_type;
   std::string compression_type;
 
   RGWZonePlacementInfo() : index_type(RGWBIType_Normal) {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(6, 1, bl);
+    ENCODE_START(7, 1, bl);
     encode(index_pool.to_str(), bl);
     encode(data_pool.to_str(), bl);
     encode(data_extra_pool.to_str(), bl);
@@ -353,7 +354,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   /*
    * return data pool of the head object
    */
-  bool get_head_data_pool(const std::string& placement_id, const rgw_obj& obj, rgw_pool *pool) const {
+  bool get_head_data_pool(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_pool *pool) const {
     const rgw_data_placement_target& explicit_placement = obj.bucket.explicit_placement;
     if (!explicit_placement.data_pool.empty()) {
       if (!obj.in_extra_data) {
@@ -363,15 +364,15 @@ struct RGWZoneParams : RGWSystemMetaObj {
       }
       return true;
     }
-    if (placement_id.empty()) {
+    if (placement_rule.empty()) {
       return false;
     }
-    auto iter = placement_pools.find(placement_id);
+    auto iter = placement_pools.find(placement_rule.name);
     if (iter == placement_pools.end()) {
       return false;
     }
     if (!obj.in_extra_data) {
-      *pool = iter->second.data_pool;
+      *pool = iter->second.get_data_pool(placement_rule.storage_class);
     } else {
       *pool = iter->second.get_data_extra_pool();
     }
@@ -485,10 +486,11 @@ struct RGWDefaultZoneGroupInfo {
 WRITE_CLASS_ENCODER(RGWDefaultZoneGroupInfo)
 
 struct RGWZoneGroupPlacementTarget {
-  std::string name;
-  set<std::string> tags;
+  string name;
+  set<string> tags;
+  set<string> storage_classes;
 
-  bool user_permitted(list<std::string>& user_tags) const {
+  bool user_permitted(list<string>& user_tags) const {
     if (tags.empty()) {
       return true;
     }
@@ -501,23 +503,29 @@ struct RGWZoneGroupPlacementTarget {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(name, bl);
     encode(tags, bl);
+    encode(storage_classes, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(name, bl);
     decode(tags, bl);
+    if (struct_v >= 2) {
+      decode(storage_classes, bl);
+    }
+    if (storage_classes.empty()) {
+      storage_classes.insert(RGW_STORAGE_CLASS_STANDARD);
+    }
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTarget)
-
 
 struct RGWZoneGroup : public RGWSystemMetaObj {
   std::string api_name;
@@ -528,7 +536,7 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
   map<std::string, RGWZone> zones;
 
   map<std::string, RGWZoneGroupPlacementTarget> placement_targets;
-  std::string default_placement;
+  rgw_placement_rule default_placement;
 
   list<std::string> hostnames;
   list<std::string> hostnames_s3website;

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -310,6 +310,9 @@ struct RGWZonePlacementInfo {
 
     return storage_class->data_pool.get_value_or(no_pool);
   }
+  const rgw_pool& get_standard_data_pool() const {
+    return get_data_pool(RGW_STORAGE_CLASS_STANDARD);
+  }
 
   const string& get_compression_type(const string& sc) const {
     const RGWZoneStorageClass *storage_class;

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -148,36 +148,131 @@ public:
 };
 WRITE_CLASS_ENCODER(RGWSystemMetaObj)
 
+struct RGWZoneStorageClass {
+  boost::optional<rgw_pool> data_pool;
+  boost::optional<std::string> compression_type;
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(data_pool, bl);
+    encode(compression_type, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(data_pool, bl);
+    decode(compression_type, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(RGWZoneStorageClass)
+
+
+class RGWZoneStorageClasses {
+  map<string, RGWZoneStorageClass> m;
+
+  /* in memory only */
+  RGWZoneStorageClass *standard_class{&m[RGW_STORAGE_CLASS_STANDARD]};
+
+public:
+  RGWZoneStorageClasses() {}
+  RGWZoneStorageClasses(const RGWZoneStorageClasses& rhs) {
+    m = rhs.m;
+    standard_class = &m[RGW_STORAGE_CLASS_STANDARD];
+  }
+  RGWZoneStorageClasses& operator=(const RGWZoneStorageClasses& rhs) {
+    m = rhs.m;
+    standard_class = &m[RGW_STORAGE_CLASS_STANDARD];
+    return *this;
+  }
+
+  const RGWZoneStorageClass& get_standard() const {
+    return *standard_class;
+  }
+
+  bool find(const string& sc, const RGWZoneStorageClass **pstorage_class) const {
+    auto iter = m.find(sc);
+    if (iter == m.end()) {
+      return false;
+    }
+    *pstorage_class = &iter->second;
+    return true;
+  }
+
+  const map<string, RGWZoneStorageClass>& get_all() const {
+    return m;
+  }
+
+  map<string, RGWZoneStorageClass>& get_all() {
+    return m;
+  }
+
+  void set_storage_class(const string& sc, const rgw_pool *data_pool, const string *compression_type) {
+    const string *psc = &sc;
+    if (sc.empty()) {
+      psc = &RGW_STORAGE_CLASS_STANDARD;
+    }
+    RGWZoneStorageClass& storage_class = m[*psc];
+    if (data_pool) {
+      storage_class.data_pool = *data_pool;
+    }
+    if (compression_type) {
+      storage_class.compression_type = *compression_type;
+    }
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(m, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(m, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(RGWZoneStorageClasses)
+
 struct RGWZonePlacementInfo {
   rgw_pool index_pool;
-  rgw_pool standard_data_pool;
   rgw_pool data_extra_pool; /* if not set we should use data_pool */
-  map<string, rgw_pool> data_pools;
+  RGWZoneStorageClasses storage_classes;
   RGWBucketIndexType index_type;
-  std::string compression_type;
 
   RGWZonePlacementInfo() : index_type(RGWBIType_Normal) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(7, 1, bl);
     encode(index_pool.to_str(), bl);
-    encode(data_pool.to_str(), bl);
+    rgw_pool standard_data_pool = get_data_pool(RGW_STORAGE_CLASS_STANDARD);
+    encode(standard_data_pool.to_str(), bl);
     encode(data_extra_pool.to_str(), bl);
     encode((uint32_t)index_type, bl);
-    encode(compression_type, bl);
+    string standard_compression_type = get_compression_type(RGW_STORAGE_CLASS_STANDARD);
+    encode(standard_compression_type, bl);
+    encode(storage_classes, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(6, bl);
-    std::string index_pool_str;
-    std::string data_pool_str;
+    DECODE_START(7, bl);
+    string index_pool_str;
+    string data_pool_str;
     decode(index_pool_str, bl);
     index_pool = rgw_pool(index_pool_str);
     decode(data_pool_str, bl);
-    data_pool = rgw_pool(data_pool_str);
+    rgw_pool standard_data_pool(data_pool_str);
     if (struct_v >= 4) {
-      std::string data_extra_pool_str;
+      string data_extra_pool_str;
       decode(data_extra_pool_str, bl);
       data_extra_pool = rgw_pool(data_extra_pool_str);
     }
@@ -186,19 +281,49 @@ struct RGWZonePlacementInfo {
       decode(it, bl);
       index_type = (RGWBucketIndexType)it;
     }
+    string standard_compression_type;
     if (struct_v >= 6) {
-      decode(compression_type, bl);
+      decode(standard_compression_type, bl);
+    }
+    if (struct_v >= 7) {
+      decode(storage_classes, bl);
+    } else {
+      storage_classes.set_storage_class(RGW_STORAGE_CLASS_STANDARD, &standard_data_pool,
+                                        (!standard_compression_type.empty() ? &standard_compression_type : nullptr));
     }
     DECODE_FINISH(bl);
   }
   const rgw_pool& get_data_extra_pool() const {
+    static rgw_pool no_pool;
     if (data_extra_pool.empty()) {
-      return data_pool;
+      return storage_classes.get_standard().data_pool.get_value_or(no_pool);
     }
     return data_extra_pool;
   }
+  const rgw_pool& get_data_pool(const string& sc) const {
+    const RGWZoneStorageClass *storage_class;
+    static rgw_pool no_pool;
+
+    if (!storage_classes.find(sc, &storage_class)) {
+      return storage_classes.get_standard().data_pool.get_value_or(no_pool);
+    }
+
+    return storage_class->data_pool.get_value_or(no_pool);
+  }
+
+  const string& get_compression_type(const string& sc) const {
+    const RGWZoneStorageClass *storage_class;
+    static string no_compression;
+
+    if (!storage_classes.find(sc, &storage_class)) {
+      return no_compression;
+    }
+    return storage_class->compression_type.get_value_or(no_compression);
+  }
+
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+
 };
 WRITE_CLASS_ENCODER(RGWZonePlacementInfo)
 
@@ -249,7 +374,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   int create(bool exclusive = true) override;
   int fix_pool_names();
 
-  const std::string& get_compression_type(const std::string& placement_rule) const;
+  const string& get_compression_type(const rgw_placement_rule& placement_rule) const;
   
   void encode(bufferlist& bl) const override {
     ENCODE_START(12, 1, bl);

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -933,9 +933,9 @@ bool RGWSI_Zone::is_syncing_bucket_meta(const rgw_bucket& bucket)
 }
 
 
-int RGWSI_Zone::select_new_bucket_location(RGWUserInfo& user_info, const string& zonegroup_id, const string& request_rule,
-                                         string *pselected_rule_name, RGWZonePlacementInfo *rule_info)
-
+int RGWSI_Zone::select_new_bucket_location(RGWUserInfo& user_info, const string& zonegroup_id,
+                                         const rgw_placement_rule& request_rule,
+                                         rgw_placement_rule *pselected_rule_name, RGWZonePlacementInfo *rule_info)
 {
   /* first check that zonegroup exists within current period. */
   RGWZoneGroup zonegroup;
@@ -945,29 +945,34 @@ int RGWSI_Zone::select_new_bucket_location(RGWUserInfo& user_info, const string&
     return ret;
   }
 
+  const rgw_placement_rule *used_rule;
+
   /* find placement rule. Hierarchy: request rule > user default rule > zonegroup default rule */
   std::map<std::string, RGWZoneGroupPlacementTarget>::const_iterator titer;
 
-  if (!request_rule.empty()) {
-    titer = zonegroup.placement_targets.find(request_rule);
+  if (!request_rule.name.empty()) {
+    used_rule = &request_rule;
+    titer = zonegroup.placement_targets.find(request_rule.name);
     if (titer == zonegroup.placement_targets.end()) {
       ldout(cct, 0) << "could not find requested placement id " << request_rule 
                     << " within zonegroup " << dendl;
       return -ERR_INVALID_LOCATION_CONSTRAINT;
     }
   } else if (!user_info.default_placement.empty()) {
-    titer = zonegroup.placement_targets.find(user_info.default_placement);
+    used_rule = &user_info.default_placement;
+    titer = zonegroup.placement_targets.find(user_info.default_placement.name);
     if (titer == zonegroup.placement_targets.end()) {
       ldout(cct, 0) << "could not find user default placement id " << user_info.default_placement
                     << " within zonegroup " << dendl;
       return -ERR_INVALID_LOCATION_CONSTRAINT;
     }
   } else {
-    if (zonegroup.default_placement.empty()) { // zonegroup default rule as fallback, it should not be empty.
+    if (zonegroup.default_placement.name.empty()) { // zonegroup default rule as fallback, it should not be empty.
       ldout(cct, 0) << "misconfiguration, zonegroup default placement id should not be empty." << dendl;
       return -ERR_ZONEGROUP_DEFAULT_PLACEMENT_MISCONFIGURATION;
     } else {
-      titer = zonegroup.placement_targets.find(zonegroup.default_placement);
+      used_rule = &zonegroup.default_placement;
+      titer = zonegroup.placement_targets.find(zonegroup.default_placement.name);
       if (titer == zonegroup.placement_targets.end()) {
         ldout(cct, 0) << "could not find zonegroup default placement id " << zonegroup.default_placement
                       << " within zonegroup " << dendl;
@@ -983,15 +988,24 @@ int RGWSI_Zone::select_new_bucket_location(RGWUserInfo& user_info, const string&
     return -EPERM;
   }
 
-  if (pselected_rule_name)
-    *pselected_rule_name = titer->first;
+  const string *storage_class = &request_rule.storage_class;
 
-  return select_bucket_location_by_rule(titer->first, rule_info);
+  if (storage_class->empty()) {
+    storage_class = &used_rule->storage_class;
+  }
+
+  rgw_placement_rule rule(titer->first, *storage_class);
+
+  if (pselected_rule_name) {
+    *pselected_rule_name = rule;
+  }
+
+  return select_bucket_location_by_rule(rule, rule_info);
 }
 
-int RGWSI_Zone::select_bucket_location_by_rule(const string& location_rule, RGWZonePlacementInfo *rule_info)
+int RGWSI_Zone::select_bucket_location_by_rule(const rgw_placement_rule& location_rule, RGWZonePlacementInfo *rule_info)
 {
-  if (location_rule.empty()) {
+  if (location_rule.name.empty()) {
     /* we can only reach here if we're trying to set a bucket location from a bucket
      * created on a different zone, using a legacy / default pool configuration
      */
@@ -1007,7 +1021,7 @@ int RGWSI_Zone::select_bucket_location_by_rule(const string& location_rule, RGWZ
    * checking it for the local zone, because that's where this bucket object is going to
    * reside.
    */
-  map<string, RGWZonePlacementInfo>::iterator piter = get_zone_params().placement_pools.find(location_rule);
+  map<string, RGWZonePlacementInfo>::iterator piter = get_zone_params().placement_pools.find(location_rule.name);
   if (piter == get_zone_params().placement_pools.end()) {
     /* couldn't find, means we cannot really place data for this bucket in this zone */
     if (get_zonegroup().equals(zonegroup->get_id())) {
@@ -1022,6 +1036,8 @@ int RGWSI_Zone::select_bucket_location_by_rule(const string& location_rule, RGWZ
     }
   }
 
+#warning FIXME check that location_rule.storage_class exists in piter->second
+
   RGWZonePlacementInfo& placement_info = piter->second;
 
   if (rule_info) {
@@ -1031,16 +1047,17 @@ int RGWSI_Zone::select_bucket_location_by_rule(const string& location_rule, RGWZ
   return 0;
 }
 
-int RGWSI_Zone::select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, const string& placement_rule,
-                                      string *pselected_rule_name, RGWZonePlacementInfo *rule_info)
+int RGWSI_Zone::select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id,
+                                        const rgw_placement_rule& placement_rule,
+                                        rgw_placement_rule *pselected_rule, RGWZonePlacementInfo *rule_info)
 {
   if (!get_zone_params().placement_pools.empty()) {
     return select_new_bucket_location(user_info, zonegroup_id, placement_rule,
-                                      pselected_rule_name, rule_info);
+                                      pselected_rule, rule_info);
   }
 
-  if (pselected_rule_name) {
-    pselected_rule_name->clear();
+  if (pselected_rule) {
+    pselected_rule->clear();
   }
 
   if (rule_info) {
@@ -1113,7 +1130,7 @@ read_omap:
   }
   pool_name = miter->first;
 
-  rule_info->data_pool = pool_name;
+  rule_info->data_pools[RGW_STORAGE_CLASS_STANDARD] = pool_name;
   rule_info->data_extra_pool = pool_name;
   rule_info->index_pool = pool_name;
   rule_info->index_type = RGWBIType_Normal;

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -1130,7 +1130,9 @@ read_omap:
   }
   pool_name = miter->first;
 
-  rule_info->data_pools[RGW_STORAGE_CLASS_STANDARD] = pool_name;
+  rgw_pool pool = pool_name;
+
+  rule_info->storage_classes.set_storage_class(RGW_STORAGE_CLASS_STANDARD, &pool, nullptr);
   rule_info->data_extra_pool = pool_name;
   rule_info->index_pool = pool_name;
   rule_info->index_type = RGWBIType_Normal;

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -1036,7 +1036,12 @@ int RGWSI_Zone::select_bucket_location_by_rule(const rgw_placement_rule& locatio
     }
   }
 
-#warning FIXME check that location_rule.storage_class exists in piter->second
+  auto storage_class = location_rule.get_storage_class();
+  if (!piter->second.storage_class_exists(storage_class)) {
+    ldout(cct, 5) << "requested storage class does not exist: " << storage_class << dendl;
+    return -EINVAL;
+  }
+
 
   RGWZonePlacementInfo& placement_info = piter->second;
 

--- a/src/rgw/services/svc_zone.h
+++ b/src/rgw/services/svc_zone.h
@@ -103,12 +103,14 @@ public:
   RGWRESTConn *get_zone_conn_by_name(const string& name);
   bool find_zone_id_by_name(const string& name, string *id);
 
-  int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, const string& rule,
-                              string *pselected_rule_name, RGWZonePlacementInfo *rule_info);
+  int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id,
+                              const rgw_placement_rule& rule,
+                              rgw_placement_rule *pselected_rule, RGWZonePlacementInfo *rule_info);
   int select_legacy_bucket_placement(RGWZonePlacementInfo *rule_info);
-  int select_new_bucket_location(RGWUserInfo& user_info, const string& zonegroup_id, const string& rule,
-                                 string *pselected_rule_name, RGWZonePlacementInfo *rule_info);
-  int select_bucket_location_by_rule(const string& location_rule, RGWZonePlacementInfo *rule_info);
+  int select_new_bucket_location(RGWUserInfo& user_info, const string& zonegroup_id,
+                                 const rgw_placement_rule& rule,
+                                 rgw_placement_rule *pselected_rule_name, RGWZonePlacementInfo *rule_info);
+  int select_bucket_location_by_rule(const rgw_placement_rule& location_rule, RGWZonePlacementInfo *rule_info);
 
   int add_bucket_placement(const rgw_pool& new_pool);
   int remove_bucket_placement(const rgw_pool& old_pool);

--- a/src/test/rgw/test_rgw_common.cc
+++ b/src/test/rgw/test_rgw_common.cc
@@ -6,11 +6,13 @@ void test_rgw_add_placement(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params,
 
   RGWZonePlacementInfo& pinfo = zone_params->placement_pools[name];
   pinfo.index_pool = rgw_pool(name + ".index").to_str();
-  pinfo.data_pool = rgw_pool(name + ".data").to_str();
+
+  rgw_pool data_pool(name + ".data");
+  pinfo.storage_classes.set_storage_class(RGW_STORAGE_CLASS_STANDARD, &data_pool, nullptr);
   pinfo.data_extra_pool = rgw_pool(name + ".extra").to_str();
-  
+
   if (is_default) {
-    zonegroup->default_placement = name;
+    zonegroup->default_placement = rgw_placement_rule(name, RGW_STORAGE_CLASS_STANDARD);
   }
 }
 

--- a/src/test/rgw/test_rgw_common.h
+++ b/src/test/rgw/test_rgw_common.h
@@ -468,15 +468,15 @@ struct test_rgw_env {
 
   test_rgw_env() {
     test_rgw_init_env(&zonegroup, &zone_params);
-    default_placement.data_pool = rgw_pool(zone_params.placement_pools[zonegroup.default_placement].data_pool);
-    default_placement.data_extra_pool =  rgw_pool(zone_params.placement_pools[zonegroup.default_placement].data_extra_pool);
+    default_placement.data_pool = rgw_pool(zone_params.placement_pools[zonegroup.default_placement.name].get_standard_data_pool());
+    default_placement.data_extra_pool =  rgw_pool(zone_params.placement_pools[zonegroup.default_placement.name].data_extra_pool);
   }
 
   rgw_data_placement_target get_placement(const std::string& placement_id) {
     const RGWZonePlacementInfo& pi = zone_params.placement_pools[placement_id];
     rgw_data_placement_target pt;
     pt.index_pool = pi.index_pool;
-    pt.data_pool = pi.data_pool;
+    pt.data_pool = pi.get_standard_data_pool();
     pt.data_extra_pool = pi.data_extra_pool;
     return pt;
   }

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -128,7 +128,7 @@ void append_stripes(list<rgw_obj> *objs, RGWObjManifest& manifest, uint64_t obj_
 }
 
 static void gen_obj(test_rgw_env& env, uint64_t obj_size, uint64_t head_max_size, uint64_t stripe_size,
-                    RGWObjManifest *manifest, const string& placement_id, rgw_bucket *bucket, rgw_obj *head, RGWObjManifest::generator *gen,
+                    RGWObjManifest *manifest, const rgw_placement_rule& placement_rule, rgw_bucket *bucket, rgw_obj *head, RGWObjManifest::generator *gen,
                     list<rgw_obj> *test_objs)
 {
   manifest->set_trivial_rule(head_max_size, stripe_size);
@@ -136,7 +136,7 @@ static void gen_obj(test_rgw_env& env, uint64_t obj_size, uint64_t head_max_size
   test_rgw_init_bucket(bucket, "buck");
 
   *head = rgw_obj(*bucket, "oid");
-  gen->create_begin(g_ceph_context, manifest, placement_id, *bucket, *head);
+  gen->create_begin(g_ceph_context, manifest, placement_rule, nullptr, *bucket, *head);
 
   append_head(test_objs, *head);
   cout << "test_objs.size()=" << test_objs->size() << std::endl;
@@ -313,7 +313,8 @@ TEST(TestRGWManifest, multipart) {
     rgw_obj head;
     for (ofs = 0; ofs < part_size; ofs += stripe_size) {
       if (ofs == 0) {
-        int r = gen.create_begin(g_ceph_context, &manifest, env.zonegroup.default_placement, bucket, head);
+        rgw_placement_rule rule(env.zonegroup.default_placement.name, RGW_STORAGE_CLASS_STANDARD);
+        int r = gen.create_begin(g_ceph_context, &manifest, rule, nullptr, bucket, head);
         ASSERT_EQ(r, 0);
         continue;
       }

--- a/src/test/rgw/test_rgw_obj.cc
+++ b/src/test/rgw/test_rgw_obj.cc
@@ -200,7 +200,7 @@ TEST(TestRGWObj, obj_to_raw) {
   for (auto name : { "myobj", "_myobj", "_myobj_"}) {
     for (auto inst : { "", "inst"}) {
       for (auto ns : { "", "ns"}) {
-        test_obj_to_raw(env, b, name, inst, ns, env.zonegroup.default_placement);
+        test_obj_to_raw(env, b, name, inst, ns, env.zonegroup.default_placement.name);
         test_obj_to_raw(env, eb, name, inst, ns, string());
       }
     }


### PR DESCRIPTION
1.  fix list multipart and list bucketmultipart

2. when upload object with storage class STANDARD_IA other than STANDARD,  the multipart part header should write the correct pool

the test follow show we multipart upload large file, beforce complete upload, we abort, and  the part header object will never be delete, and the same time,  default.rgw.buckets.data-ia pool have the same name object
```
s3cmd -c user1.s3cfg put 512M s3://test1/3 --storage-class=STANDARD_IA
s3cmd -c user1.s3cfg abortmp s3://test1/3 2~0S62gZohyfeNPARe0xN6-3PWsD64diR
./bin/ceph df -c ceph.conf
./bin/rados -p default.rgw.buckets.data ls -c ceph.conf
6945cb90-d5b9-4abf-9662-a7b403a993cf.4192.1__multipart_3.2~0S62gZohyfeNPARe0xN6-3PWsD64diR.2
6945cb90-d5b9-4abf-9662-a7b403a993cf.4192.1__multipart_3.2~0S62gZohyfeNPARe0xN6-3PWsD64diR.1
```

3. fix post object when set storage class

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>